### PR TITLE
28 add redaction support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -9,10 +9,13 @@ const org = "SC2";
 const logo = "static/logo.png";
 const color = "AACEFF";
 var is_draft = false;
+var is_redact = false;
 
 pub fn build(b: *std.Build) !void {
     const draft_option = b.option(bool, "draft", "Produce pdfs with a draft watermark") orelse false;
     is_draft = draft_option;
+    const redact_option = b.option(bool, "redact", "Produce pdfs with redacted information") orelse false;
+    is_redact = redact_option;
 
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
@@ -184,6 +187,7 @@ fn build_pdfs(b: *std.Build, step: *std.Build.Step, exe: *std.Build.Step.Compile
         run_cmd.addArg("-o");
         _ = run_cmd.addOutputDirectoryArg(".tmp");
         if (is_draft) run_cmd.addArg("-d");
+        if (is_redact) run_cmd.addArg("-r");
 
         // wf.step.dependOn(&run_cmd.step);
         // inst.step.dependOn(&run_cmd.step);

--- a/build.zig
+++ b/build.zig
@@ -156,7 +156,7 @@ fn build_web(step: *std.Build.Step, _: std.Build.Step.MakeOptions) !void {
 fn build_pdfs(b: *std.Build, step: *std.Build.Step, exe: *std.Build.Step.Compile) !void {
     const wf = b.addWriteFiles();
 
-    const markdown_files = b.run(&.{ "git", "ls-files", "content/policies/data/*.md" });
+    const markdown_files = b.run(&.{ "git", "ls-files", "content/policies/*.md" });
     var lines = std.mem.tokenizeScalar(u8, markdown_files, '\n');
 
     std.fs.cwd().makeDir(".tmp") catch |e| {

--- a/config.toml
+++ b/config.toml
@@ -27,6 +27,7 @@ feed  = false
 render = false 
 
 [extra]
+redact = true
 policy_root = "policies/_index.md"
 organization = "Star City Security Consulting"
 logo = "logo.png"

--- a/content/policies/test_policy.md
+++ b/content/policies/test_policy.md
@@ -15,7 +15,6 @@ taxonomies:
     - HRS-05.3
     - HRS-05.4
     - HRS-05.5
-
 extra:
   owner: SC2
   last_reviewed: 2025-02-24
@@ -24,12 +23,12 @@ extra:
       description: Demo revision.
       revised_by: Ben Craton
       approved_by: Ben Craton
-      version: "1.0"
+      version: "1.1"
     - date: 2024-02-11
       description: Initial version.
       revised_by: Ben Craton
       approved_by: Ben Craton
-      version: "0.0"
+      version: "1.0"
 ---
 
 ## Introduction

--- a/content/policies/test_policy.md
+++ b/content/policies/test_policy.md
@@ -1,0 +1,53 @@
+---
+title: "Test Policy"
+description: "A policy for testing purposes"
+summary: ""
+date: 2024-11-13
+weight: 10
+taxonomies:
+  TSC2017:
+    - CC2.1
+    - P4.1
+  SCF:
+    - HRS-05
+    - HRS-05.1
+    - HRS-05.2
+    - HRS-05.3
+    - HRS-05.4
+    - HRS-05.5
+
+extra:
+  owner: SC2
+  last_reviewed: 2025-02-24
+  major_revisions:
+    - date: 2025-06-24
+      description: Demo revision.
+      revised_by: Ben Craton
+      approved_by: Ben Craton
+      version: "1.0"
+    - date: 2024-02-11
+      description: Initial version.
+      revised_by: Ben Craton
+      approved_by: Ben Craton
+      version: "0.0"
+---
+
+## Introduction
+
+{{ org() }} is committed to testing its policy center.
+
+## Mermaid
+
+{% mermaid() %}
+graph TD
+A[Start] --> B{Is it a test?}
+B -- Yes --> C[Run tests]
+B -- No --> D[End]
+C --> D
+{% end %}
+
+## Redaction
+
+{% redact() %}
+This is a test policy for demonstration purposes. It contains sensitive information that should not be disclosed.
+{% end %}

--- a/devbox.lock
+++ b/devbox.lock
@@ -2,16 +2,16 @@
   "lockfile_version": "1",
   "packages": {
     "github:NixOS/nixpkgs/nixpkgs-unstable": {
-      "last_modified": "2025-06-14T12:19:57Z",
-      "resolved": "github:NixOS/nixpkgs/41da1e3ea8e23e094e5e3eeb1e6b830468a7399e?lastModified=1749903597&narHash=sha256-jp0D4vzBcRKwNZwfY4BcWHemLGUs4JrS3X9w5k%2FJYDA%3D"
+      "last_modified": "2025-06-24T02:18:21Z",
+      "resolved": "github:NixOS/nixpkgs/69dfebb3d175bde602f612915c5576a41b18486b?lastModified=1750731501&narHash=sha256-Ah4qq%2BSbwMaGkuXCibyg%2BFwn00el4KmI3XFX6htfDuk%3D"
     },
     "github:sc2in/eisvogel-tex#": {
       "last_modified": "2024-06-17T20:03:57Z",
       "resolved": "github:sc2in/eisvogel-tex/9384c4be4f7b0944baf6aa06b1c48edde3f285ac?lastModified=1718654637&narHash=sha256-38jKMgzaQ8oBZ8yvvVFb%2FtyUZAN1digOtDp1NuhBc4A%3D"
     },
     "imagemagick@latest": {
-      "last_modified": "2025-06-06T12:35:49Z",
-      "resolved": "github:NixOS/nixpkgs/a4ff0e3c64846abea89662bfbacf037ef4b34207#imagemagick",
+      "last_modified": "2025-06-22T15:15:55Z",
+      "resolved": "github:NixOS/nixpkgs/3078b9a9e75f1790e6d6ef9955fdc6a2d1740cc6#imagemagick",
       "source": "devbox-search",
       "version": "7.1.1-47",
       "systems": {
@@ -19,79 +19,79 @@
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/kz7yrb6zm3f3hahbfqpka1qcxa2chyfb-imagemagick-7.1.1-47",
+              "path": "/nix/store/3w06dz5yczsy9l5iad6x15if2fsj4rwz-imagemagick-7.1.1-47",
               "default": true
             },
             {
-              "name": "doc",
-              "path": "/nix/store/zn44a6zd44xyjyl0khhgl0wx2amgc86y-imagemagick-7.1.1-47-doc"
+              "name": "dev",
+              "path": "/nix/store/iv03zy153mgq00m3xpx4jcz6i6q2g923-imagemagick-7.1.1-47-dev"
             },
             {
-              "name": "dev",
-              "path": "/nix/store/fcs82x7djv4jxywgnc8z9cb5n0sdvd7r-imagemagick-7.1.1-47-dev"
+              "name": "doc",
+              "path": "/nix/store/wnw20gk6hpss2sbcxzzj9cxn0ar11s4j-imagemagick-7.1.1-47-doc"
             }
           ],
-          "store_path": "/nix/store/kz7yrb6zm3f3hahbfqpka1qcxa2chyfb-imagemagick-7.1.1-47"
+          "store_path": "/nix/store/3w06dz5yczsy9l5iad6x15if2fsj4rwz-imagemagick-7.1.1-47"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/h5vv71jlnzxy5n5zw4a12p29lzjkbb6l-imagemagick-7.1.1-47",
+              "path": "/nix/store/dasd572y8gbz48bi7dlq5wvw86i3l95z-imagemagick-7.1.1-47",
               "default": true
             },
             {
               "name": "dev",
-              "path": "/nix/store/yx1nqhimimy054ly4vnc7nca88wx0i1g-imagemagick-7.1.1-47-dev"
+              "path": "/nix/store/h8bbyl2m8m5sgqaa6rshjjb2c9j5kyfa-imagemagick-7.1.1-47-dev"
             },
             {
               "name": "doc",
-              "path": "/nix/store/6gjpaz57ksrvfiirfws1ja5jlfgwgr5k-imagemagick-7.1.1-47-doc"
+              "path": "/nix/store/6wkhrmmdrm6fwwciblmkzn9v54b7fp5r-imagemagick-7.1.1-47-doc"
             }
           ],
-          "store_path": "/nix/store/h5vv71jlnzxy5n5zw4a12p29lzjkbb6l-imagemagick-7.1.1-47"
+          "store_path": "/nix/store/dasd572y8gbz48bi7dlq5wvw86i3l95z-imagemagick-7.1.1-47"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/cxihbm2zrjjjk0py84xq9jw37m0015vg-imagemagick-7.1.1-47",
+              "path": "/nix/store/hydd07w5m5k3crqp9gyw6k4gv5ila0x4-imagemagick-7.1.1-47",
               "default": true
             },
             {
-              "name": "doc",
-              "path": "/nix/store/rflc98bc2aw904i1lmvy4z1m78cn2674-imagemagick-7.1.1-47-doc"
+              "name": "dev",
+              "path": "/nix/store/7yqlrkfapcw2da81aywnia7x3k2y27i0-imagemagick-7.1.1-47-dev"
             },
             {
-              "name": "dev",
-              "path": "/nix/store/wphqgvfy7qvz273vdndz2xd9zbn0y8ii-imagemagick-7.1.1-47-dev"
+              "name": "doc",
+              "path": "/nix/store/dv1x6pzqa8bk2gmnaq00nk6klhjpzkcc-imagemagick-7.1.1-47-doc"
             }
           ],
-          "store_path": "/nix/store/cxihbm2zrjjjk0py84xq9jw37m0015vg-imagemagick-7.1.1-47"
+          "store_path": "/nix/store/hydd07w5m5k3crqp9gyw6k4gv5ila0x4-imagemagick-7.1.1-47"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/z4jnh4k7lmydfp6zcin84qy2j2v4w19i-imagemagick-7.1.1-47",
+              "path": "/nix/store/3rvn3p974bi9llyfr1sjrg02911l52b7-imagemagick-7.1.1-47",
               "default": true
             },
             {
               "name": "dev",
-              "path": "/nix/store/4pivv1m7fbawr7alqiymvmfgbx62i0yh-imagemagick-7.1.1-47-dev"
+              "path": "/nix/store/c1na7xdwr8yd7vr91sqpl6avi0fqz8rf-imagemagick-7.1.1-47-dev"
             },
             {
               "name": "doc",
-              "path": "/nix/store/1xny9xpnrkfq3swk86x0q6rmyqb1wr1c-imagemagick-7.1.1-47-doc"
+              "path": "/nix/store/hwl4bx329n402h935qls985jyxwppsry-imagemagick-7.1.1-47-doc"
             }
           ],
-          "store_path": "/nix/store/z4jnh4k7lmydfp6zcin84qy2j2v4w19i-imagemagick-7.1.1-47"
+          "store_path": "/nix/store/3rvn3p974bi9llyfr1sjrg02911l52b7-imagemagick-7.1.1-47"
         }
       }
     },
     "mermaid-filter@latest": {
-      "last_modified": "2025-06-05T08:10:37Z",
-      "resolved": "github:NixOS/nixpkgs/ec62ae342c340d24289735e31eb9155261cd5fe7#mermaid-filter",
+      "last_modified": "2025-06-20T02:24:11Z",
+      "resolved": "github:NixOS/nixpkgs/076e8c6678d8c54204abcb4b1b14c366835a58bb#mermaid-filter",
       "source": "devbox-search",
       "version": "1.4.7",
       "systems": {
@@ -99,27 +99,27 @@
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/zp7n5kk0394j8z5qaxmwnc5rck5k2d9q-mermaid-filter-1.4.7",
+              "path": "/nix/store/fc2xw50xcqkcygvfdz2cwvgnw02x3i1x-mermaid-filter-1.4.7",
               "default": true
             }
           ],
-          "store_path": "/nix/store/zp7n5kk0394j8z5qaxmwnc5rck5k2d9q-mermaid-filter-1.4.7"
+          "store_path": "/nix/store/fc2xw50xcqkcygvfdz2cwvgnw02x3i1x-mermaid-filter-1.4.7"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/7sfkhvs9qbbjd718rfs405x8q8dy524x-mermaid-filter-1.4.7",
+              "path": "/nix/store/yn9vks9q97qcch1sygdq89r8fyjb523y-mermaid-filter-1.4.7",
               "default": true
             }
           ],
-          "store_path": "/nix/store/7sfkhvs9qbbjd718rfs405x8q8dy524x-mermaid-filter-1.4.7"
+          "store_path": "/nix/store/yn9vks9q97qcch1sygdq89r8fyjb523y-mermaid-filter-1.4.7"
         }
       }
     },
     "pandoc@latest": {
-      "last_modified": "2025-05-16T20:19:48Z",
-      "resolved": "github:NixOS/nixpkgs/12a55407652e04dcf2309436eb06fef0d3713ef3#pandoc",
+      "last_modified": "2025-06-20T02:24:11Z",
+      "resolved": "github:NixOS/nixpkgs/076e8c6678d8c54204abcb4b1b14c366835a58bb#pandoc",
       "source": "devbox-search",
       "version": "3.6",
       "systems": {
@@ -127,47 +127,47 @@
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/yjsgvx95rxs8z7kq8k64ihrjjcwhxxgv-pandoc-cli-3.6",
+              "path": "/nix/store/22qd3hi8finw0hrx7815a3idkslhifwv-pandoc-cli-3.6",
               "default": true
             }
           ],
-          "store_path": "/nix/store/yjsgvx95rxs8z7kq8k64ihrjjcwhxxgv-pandoc-cli-3.6"
+          "store_path": "/nix/store/22qd3hi8finw0hrx7815a3idkslhifwv-pandoc-cli-3.6"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/768w741p84mdgmawcbsr5n2iyg9c5hri-pandoc-cli-3.6",
+              "path": "/nix/store/npsj8h6vbpfcryz3ii7fcc2x4hcd10by-pandoc-cli-3.6",
               "default": true
             }
           ],
-          "store_path": "/nix/store/768w741p84mdgmawcbsr5n2iyg9c5hri-pandoc-cli-3.6"
+          "store_path": "/nix/store/npsj8h6vbpfcryz3ii7fcc2x4hcd10by-pandoc-cli-3.6"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/4hrj87syc1pnslin4ydq3452z0cx9djg-pandoc-cli-3.6",
+              "path": "/nix/store/c0llc9i4p16g4inlpjql7g9385mgnfr5-pandoc-cli-3.6",
               "default": true
             }
           ],
-          "store_path": "/nix/store/4hrj87syc1pnslin4ydq3452z0cx9djg-pandoc-cli-3.6"
+          "store_path": "/nix/store/c0llc9i4p16g4inlpjql7g9385mgnfr5-pandoc-cli-3.6"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/hxzw27zvh1fxcym7wzwldz6y2b5whi22-pandoc-cli-3.6",
+              "path": "/nix/store/asadxmbcddgx2dk5nlx9fpf3hg17w7wh-pandoc-cli-3.6",
               "default": true
             }
           ],
-          "store_path": "/nix/store/hxzw27zvh1fxcym7wzwldz6y2b5whi22-pandoc-cli-3.6"
+          "store_path": "/nix/store/asadxmbcddgx2dk5nlx9fpf3hg17w7wh-pandoc-cli-3.6"
         }
       }
     },
     "watchexec@latest": {
-      "last_modified": "2025-06-05T08:10:37Z",
-      "resolved": "github:NixOS/nixpkgs/ec62ae342c340d24289735e31eb9155261cd5fe7#watchexec",
+      "last_modified": "2025-06-20T02:24:11Z",
+      "resolved": "github:NixOS/nixpkgs/076e8c6678d8c54204abcb4b1b14c366835a58bb#watchexec",
       "source": "devbox-search",
       "version": "2.3.2",
       "systems": {
@@ -175,47 +175,47 @@
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/h00xs711s683frk7ahjm96mxdh0vimhl-watchexec-2.3.2",
+              "path": "/nix/store/fxcxmjy50praw77dn7h2myhdps56a9nh-watchexec-2.3.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/h00xs711s683frk7ahjm96mxdh0vimhl-watchexec-2.3.2"
+          "store_path": "/nix/store/fxcxmjy50praw77dn7h2myhdps56a9nh-watchexec-2.3.2"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/jfqwdpv61lyncc5976pjgl352gx8ymdm-watchexec-2.3.2",
+              "path": "/nix/store/lvyazq0pfgw6y7cih1ibq8mqhmmk5ldl-watchexec-2.3.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/jfqwdpv61lyncc5976pjgl352gx8ymdm-watchexec-2.3.2"
+          "store_path": "/nix/store/lvyazq0pfgw6y7cih1ibq8mqhmmk5ldl-watchexec-2.3.2"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/lhas1n4ilv4vmhfmk57x47wnvkw538fq-watchexec-2.3.2",
+              "path": "/nix/store/n6q9djl042r9pwxf805zn399cpv96yns-watchexec-2.3.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/lhas1n4ilv4vmhfmk57x47wnvkw538fq-watchexec-2.3.2"
+          "store_path": "/nix/store/n6q9djl042r9pwxf805zn399cpv96yns-watchexec-2.3.2"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/6k8983fxhjidg0154wjcsc6p5hala7vv-watchexec-2.3.2",
+              "path": "/nix/store/hh35j1vvsd9x3mrvbalyi504b7k827q3-watchexec-2.3.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/6k8983fxhjidg0154wjcsc6p5hala7vv-watchexec-2.3.2"
+          "store_path": "/nix/store/hh35j1vvsd9x3mrvbalyi504b7k827q3-watchexec-2.3.2"
         }
       }
     },
     "zig@latest": {
-      "last_modified": "2025-05-24T21:46:02Z",
-      "resolved": "github:NixOS/nixpkgs/edb3633f9100d9277d1c9af245a4e9337a980c07#zig",
+      "last_modified": "2025-06-20T02:24:11Z",
+      "resolved": "github:NixOS/nixpkgs/076e8c6678d8c54204abcb4b1b14c366835a58bb#zig",
       "source": "devbox-search",
       "version": "0.14.1",
       "systems": {
@@ -223,63 +223,63 @@
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/1jg919rz3xjivamc2djp10bcwy4nqwhn-zig-0.14.1",
+              "path": "/nix/store/pfsg2bgyam84m30z0w3z1rdr8zk3n13v-zig-0.14.1",
               "default": true
             },
             {
               "name": "doc",
-              "path": "/nix/store/74kmfzx53xqhsx79g08shx24b7fv98a8-zig-0.14.1-doc"
+              "path": "/nix/store/aj61fyibmfc1g1f9wi7dqf3lgd5d7127-zig-0.14.1-doc"
             }
           ],
-          "store_path": "/nix/store/1jg919rz3xjivamc2djp10bcwy4nqwhn-zig-0.14.1"
+          "store_path": "/nix/store/pfsg2bgyam84m30z0w3z1rdr8zk3n13v-zig-0.14.1"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/7kp0fldzamj5ld6jwxn6sv895ngifpsk-zig-0.14.1",
+              "path": "/nix/store/kz4yyjdv7kyzkkhy6yc5wp50mdhq2dhr-zig-0.14.1",
               "default": true
             },
             {
               "name": "doc",
-              "path": "/nix/store/nwgn72nbv8yw57fp2n5xbrlmk4jw38ba-zig-0.14.1-doc"
+              "path": "/nix/store/8cn0z0qf9aifwmdmwyn1wsplsrv3aib5-zig-0.14.1-doc"
             }
           ],
-          "store_path": "/nix/store/7kp0fldzamj5ld6jwxn6sv895ngifpsk-zig-0.14.1"
+          "store_path": "/nix/store/kz4yyjdv7kyzkkhy6yc5wp50mdhq2dhr-zig-0.14.1"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/n00cnc0aly9ymd3v9wn3q3g918bg9w6l-zig-0.14.1",
+              "path": "/nix/store/ryrjg3dvjyk7pp6q1bbk4cav64g4ayd6-zig-0.14.1",
               "default": true
             },
             {
               "name": "doc",
-              "path": "/nix/store/daj1f5qmz88fndn78d83yhdy41b3iw8s-zig-0.14.1-doc"
+              "path": "/nix/store/ybalawfw739hq5yz9izn736b1j763h3w-zig-0.14.1-doc"
             }
           ],
-          "store_path": "/nix/store/n00cnc0aly9ymd3v9wn3q3g918bg9w6l-zig-0.14.1"
+          "store_path": "/nix/store/ryrjg3dvjyk7pp6q1bbk4cav64g4ayd6-zig-0.14.1"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/jb7n26fqzkbvqqwz0wm69gx0rm4cw9lg-zig-0.14.1",
+              "path": "/nix/store/xfs50swh37h0qj78sfhsg8ppl41gi10z-zig-0.14.1",
               "default": true
             },
             {
               "name": "doc",
-              "path": "/nix/store/1jl2jjkgrhfaqrig49kn6541xxqhr4vc-zig-0.14.1-doc"
+              "path": "/nix/store/f2yqlw8pxidx2d2hp0h66zrgra9wn1n2-zig-0.14.1-doc"
             }
           ],
-          "store_path": "/nix/store/jb7n26fqzkbvqqwz0wm69gx0rm4cw9lg-zig-0.14.1"
+          "store_path": "/nix/store/xfs50swh37h0qj78sfhsg8ppl41gi10z-zig-0.14.1"
         }
       }
     },
     "zls@latest": {
-      "last_modified": "2025-05-24T21:46:02Z",
-      "resolved": "github:NixOS/nixpkgs/edb3633f9100d9277d1c9af245a4e9337a980c07#zls",
+      "last_modified": "2025-06-20T02:24:11Z",
+      "resolved": "github:NixOS/nixpkgs/076e8c6678d8c54204abcb4b1b14c366835a58bb#zls",
       "source": "devbox-search",
       "version": "0.14.0",
       "systems": {
@@ -287,47 +287,47 @@
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/jyjffg5g4514x3rxjksxlbl5p3ycz6gv-zls-0.14.0",
+              "path": "/nix/store/81fczl5dzm8smqwhxg5jd9y7hm1k3g85-zls-0.14.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/jyjffg5g4514x3rxjksxlbl5p3ycz6gv-zls-0.14.0"
+          "store_path": "/nix/store/81fczl5dzm8smqwhxg5jd9y7hm1k3g85-zls-0.14.0"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/vn6hydb37490zk9ypcdlbv673cvdm9pm-zls-0.14.0",
+              "path": "/nix/store/akbp367z7bj38vdcpq15xssaalry9yn3-zls-0.14.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/vn6hydb37490zk9ypcdlbv673cvdm9pm-zls-0.14.0"
+          "store_path": "/nix/store/akbp367z7bj38vdcpq15xssaalry9yn3-zls-0.14.0"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/rlim5lpjlwgfqarcqyc03qdxzp5d8dwx-zls-0.14.0",
+              "path": "/nix/store/q9w974daph4faazn1z8q9qgxzvikx4pv-zls-0.14.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/rlim5lpjlwgfqarcqyc03qdxzp5d8dwx-zls-0.14.0"
+          "store_path": "/nix/store/q9w974daph4faazn1z8q9qgxzvikx4pv-zls-0.14.0"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/ssjfxvgrip5869vkh71biimvwkcffh2l-zls-0.14.0",
+              "path": "/nix/store/plzslh5qqrb60144w2drj5znd0hfp6av-zls-0.14.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/ssjfxvgrip5869vkh71biimvwkcffh2l-zls-0.14.0"
+          "store_path": "/nix/store/plzslh5qqrb60144w2drj5znd0hfp6av-zls-0.14.0"
         }
       }
     },
     "zola@latest": {
-      "last_modified": "2025-05-16T20:19:48Z",
-      "resolved": "github:NixOS/nixpkgs/12a55407652e04dcf2309436eb06fef0d3713ef3#zola",
+      "last_modified": "2025-06-20T02:24:11Z",
+      "resolved": "github:NixOS/nixpkgs/076e8c6678d8c54204abcb4b1b14c366835a58bb#zola",
       "source": "devbox-search",
       "version": "0.20.0",
       "systems": {
@@ -335,41 +335,41 @@
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/q8cprxnfl0lm4v0cfdmmzqd8l4ciag2v-zola-0.20.0",
+              "path": "/nix/store/gga1xz85s32nwwhzk5jccnby2jgl9nqv-zola-0.20.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/q8cprxnfl0lm4v0cfdmmzqd8l4ciag2v-zola-0.20.0"
+          "store_path": "/nix/store/gga1xz85s32nwwhzk5jccnby2jgl9nqv-zola-0.20.0"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/irxq70mxwzsj6k841bkknsiq3zary22f-zola-0.20.0",
+              "path": "/nix/store/m80rccqgrxr19cb23la6drbm50716zq7-zola-0.20.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/irxq70mxwzsj6k841bkknsiq3zary22f-zola-0.20.0"
+          "store_path": "/nix/store/m80rccqgrxr19cb23la6drbm50716zq7-zola-0.20.0"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/9i6frmhcqyxn5aa3hv0x865kp3rlkxpx-zola-0.20.0",
+              "path": "/nix/store/9phj9bqdna8z74s2wmga3jbmx83yzfy5-zola-0.20.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/9i6frmhcqyxn5aa3hv0x865kp3rlkxpx-zola-0.20.0"
+          "store_path": "/nix/store/9phj9bqdna8z74s2wmga3jbmx83yzfy5-zola-0.20.0"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/zlvyg981bhxfm49br2p1mas2i8qhks5a-zola-0.20.0",
+              "path": "/nix/store/jrj7h29mjy6zyz3zd3ifa4a1966q2ah4-zola-0.20.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/zlvyg981bhxfm49br2p1mas2i8qhks5a-zola-0.20.0"
+          "store_path": "/nix/store/jrj7h29mjy6zyz3zd3ifa4a1966q2ah4-zola-0.20.0"
         }
       }
     }

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -353,6 +353,11 @@ blockquote {
   padding: 0 20px;
 }
 
+.redaction {
+  background-color: black;
+}
+
+
 @import "fabric-icons-inline";
 @import "search";
 @import "last-review-table";

--- a/src/pandoc.zig
+++ b/src/pandoc.zig
@@ -260,23 +260,24 @@ pub fn process_md_file(
     try u.replace_org(&contents, global_config.org.?);
     try u.replace_zola_at(&contents);
     try u.replace_mermaid(&contents);
+    if (global_config.redact)
+        try u.redact(&contents);
 
     var fm = try u.get_metadata(a, &contents, global_config);
     defer fm.deinit(a);
 
-    const tmp = std.fs.cwd().createFile("tmp.md", std.fs.File.CreateFlags{ .exclusive = true }) catch |e| blk: {
+    const tmp_file = std.fs.path.basename(md.path);
+    const tmp = std.fs.cwd().createFile(tmp_file, std.fs.File.CreateFlags{ .exclusive = true }) catch |e| blk: {
         if (e == error.PathAlreadyExists) {
-            std.fs.cwd().deleteFile("tmp.md") catch unreachable;
-            break :blk try std.fs.cwd().createFile("tmp.md", std.fs.File.CreateFlags{ .exclusive = true });
+            std.fs.cwd().deleteFile(tmp_file) catch unreachable;
+            break :blk try std.fs.cwd().createFile(tmp_file, std.fs.File.CreateFlags{ .exclusive = true });
         }
         return e;
     };
-    errdefer {
-        std.fs.cwd().deleteFile("tmp.md") catch unreachable;
-    }
+
     defer {
         tmp.close();
-        std.fs.cwd().deleteFile("tmp.md") catch unreachable;
+        std.fs.cwd().deleteFile(tmp_file) catch unreachable;
     }
     try tmp.writeAll(contents.items);
 
@@ -286,7 +287,7 @@ pub fn process_md_file(
     const res_path = try std.fmt.allocPrint(a, "--resource-path={s}", .{basedir});
     try local.append(res_path);
 
-    try local.append(try a.dupe(u8, "tmp.md"));
+    try local.append(try a.dupe(u8, tmp_file));
 
     const out = try fm.filename(a);
     std.mem.replaceScalar(u8, out, ' ', '_');

--- a/src/pandoc.zig
+++ b/src/pandoc.zig
@@ -260,8 +260,7 @@ pub fn process_md_file(
     try u.replace_org(&contents, global_config.org.?);
     try u.replace_zola_at(&contents);
     try u.replace_mermaid(&contents);
-    if (global_config.redact)
-        try u.redact(&contents);
+    try u.redact(&contents, global_config.redact);
 
     var fm = try u.get_metadata(a, &contents, global_config);
     defer fm.deinit(a);

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -106,6 +106,7 @@ pub fn get_metadata(a: Allocator, txt: *Array(u8), config: anytype) !FrontMatter
 
 /// Comparator function for sorting YAML revision values in ascending order.
 pub fn revisions_lt(_: @TypeOf(.{}), a: Yaml.Value, b: Yaml.Value) bool {
+    if (a != .string or b != .string) return false;
     const as = a.string;
     const bs = b.string;
 
@@ -411,3 +412,59 @@ pub const FM = struct {
         };
     }
 };
+
+pub fn redact(txt: *Array(u8), remove: bool) !void {
+    const r: mvzr.Regex = mvzr.compile("\\{%\\s*redact\\(\\)\\s*%\\}.+?\\{%\\s*end\\s*%\\}").?;
+    if (!r.isMatch(txt.items)) return;
+
+    var new = try txt.clone();
+
+    var iter = r.iterator(txt.items);
+    while (iter.next()) |m| {
+        const s = std.mem.indexOf(u8, m.slice, "%}") orelse return error.InvalidShortCode;
+        const e = std.mem.lastIndexOf(u8, m.slice, "{%") orelse return error.InvalidShortCode;
+        const inner = m.slice[s + 2 .. e - 1];
+        const replace = if (remove) blk: {
+            const replace = try txt.allocator.alloc(u8, m.slice.len);
+            @memset(replace, 219);
+            break :blk replace;
+        } else blk: {
+            const replace = try txt.allocator.alloc(u8, m.slice.len);
+            @memset(replace, ' ');
+            @memcpy(replace[0..inner.len], inner);
+            break :blk replace;
+        };
+        defer txt.allocator.free(replace);
+
+        try new.replaceRange(m.start, m.slice.len, replace);
+        iter = r.iterator(new.items);
+    }
+    txt.deinit();
+    txt.* = new;
+}
+
+test "Redaction" {
+    const t =
+        \\{% redact() %}
+        \\This is a test policy for demonstration purposes. It contains sensitive information that should not be disclosed.
+        \\{% end %}
+    ;
+    var ts = Array(u8).init(tst.allocator);
+    defer ts.deinit();
+
+    const expected = [_]u8{0xDB} ** t.len;
+
+    try ts.appendSlice(t);
+    try redact(&ts, true);
+    std.debug.print("{s}\n", .{ts.items});
+    try tst.expectEqualStrings(&expected, ts.items);
+
+    var t2 = Array(u8).init(tst.allocator);
+    defer t2.deinit();
+
+    const expected2 = "This is a test policy for demonstration purposes. It contains sensitive information that should not be disclosed.";
+
+    try t2.appendSlice(t);
+    try redact(&t2, false);
+    try tst.expectEqualStrings(std.mem.trim(u8, expected2, "\n "), std.mem.trim(u8, t2.items, "\n "));
+}

--- a/templates/eisvogel.latex
+++ b/templates/eisvogel.latex
@@ -366,19 +366,27 @@ $endif$
 $if(graphics)$
 \usepackage{graphicx}
 \makeatletter
-\def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
-\def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}
-\makeatother
-% Scale images if necessary, so that they will not overflow the page
-% margins by default, and it is still possible to overwrite the defaults
-% using explicit options in \includegraphics[width, height, ...]{}
-\setkeys{Gin}{width=\maxwidth,height=\maxheight,keepaspectratio}
+\newsavebox\pandoc@box
+
+\newcommand*\pandocbounded[1]{% scales image to fit in text height/width
+
+ \sbox\pandoc@box{#1}%Add commentMore actions
+
+ \Gscale@div\@tempa{\textheight}{\dimexpr\ht\pandoc@box+\dp\pandoc@box\relax}%
+
+ \Gscale@div\@tempb{\linewidth}{\wd\pandoc@box}%
+
+ \ifdim\@tempb\p@<\@tempa\p@\let\@tempa\@tempb\fi% select the smaller of both
+
+ \ifdim\@tempa\p@<\p@\scalebox{\@tempa}{\usebox\pandoc@box}%
+
+ \else\usebox{\pandoc@box}%
+
+ \fi%
+}
+
 % Set default figure placement to htbp
-\makeatletter
-% Make use of float-package and set default placement for figures to H.
-% The option H means 'PUT IT HERE' (as  opposed to the standard h option which means 'You may put it here if you like').
-\usepackage{float}
-\floatplacement{figure}{$if(float-placement-figure)$$float-placement-figure$$else$H$endif$}
+\def\fps@figure{htbp}
 \makeatother
 $endif$
 $if(svg)$

--- a/templates/shortcodes/redact.html
+++ b/templates/shortcodes/redact.html
@@ -1,0 +1,9 @@
+{% set redact = config.extra.redact or false %}
+
+{% if redact %}
+<span class="redaction">
+  {% for i in range(end=(body|length)) %}_{% endfor %}
+</span>
+{% else %}
+{{ body | safe }}
+{%endif%}


### PR DESCRIPTION
This pull request introduces a new feature for handling redacted content in policy documents and improves the build process to support this functionality. It includes changes to the `build.zig` file, updates to Markdown processing, and additions to templates and styles for redaction. Additionally, it refines image scaling in LaTeX templates and fixes minor issues in utility functions.

### Redaction Feature Enhancements:

* **Added redaction support in `build.zig`:** Introduced the `is_redact` variable and the `redact` build option to enable redacting sensitive information in generated PDFs. [[1]](diffhunk://#diff-f87bb3596894756629bc39d595fb18d479dc4edf168d93a911cadcb060f10fccR12-R18) [[2]](diffhunk://#diff-f87bb3596894756629bc39d595fb18d479dc4edf168d93a911cadcb060f10fccR190)
* **Implemented redaction logic in `src/utils.zig`:** Added the `redact` function to process Markdown files, replacing sensitive content with either blacked-out text or placeholders based on configuration. Includes unit tests for the functionality.
* **Created redaction shortcode template:** Added `templates/shortcodes/redact.html` to render redacted content as blacked-out text in HTML output, controlled by the `redact` configuration flag.
* **Updated styles for redaction:** Added `.redaction` class in `sass/main.scss` to apply black background color to redacted content in web output.

### Build Process Improvements:

* **Modified Markdown file handling in `build.zig`:** Adjusted file paths to include all Markdown files under `content/policies/` instead of a specific subdirectory.
* **Refined temporary file handling in `src/pandoc.zig`:** Improved logic for creating and deleting temporary files, using dynamic names derived from input file paths. [[1]](diffhunk://#diff-f7ab9830110da62dd5ebab825a0cedb28c6565d161d4251817453a6ce3c42553R263-R279) [[2]](diffhunk://#diff-f7ab9830110da62dd5ebab825a0cedb28c6565d161d4251817453a6ce3c42553L289-R289)

### Template and Utility Updates:

* **Improved image scaling in LaTeX templates:** Replaced default image scaling logic with a more flexible approach to fit images within page dimensions.
* **Fixed metadata comparison in `src/utils.zig`:** Corrected the `revisions_lt` function to handle non-string values gracefully.

### Content Additions:

* **Added test policy document:** Created `content/policies/test_policy.md` as an example policy with redacted content and metadata for testing purposes.

These changes collectively enhance the project's ability to manage sensitive information in policy documents while improving the build system and output formats.
[Copilot is generating a summary...]