### PR TITLE
29 build pipeline

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -88,13 +88,14 @@ pub fn build(b: *std.Build) !void {
     pandoc_sh_mod.addImport("clap", clap.module("clap"));
     pandoc_sh_mod.addImport("tera", tera_mod);
     pandoc_sh_mod.addImport("datetime", pg.module("datetime"));
-    const exe = b.addExecutable(.{
+    const pandoc_sh = b.addExecutable(.{
         .root_module = pandoc_sh_mod,
         .name = "pandoc_sh",
     });
-    b.installArtifact(exe);
+    const wrapper_exe = b.addInstallArtifact(pandoc_sh, .{});
+    _ = wrapper_exe; // autofix
     var pandoc_step = b.step("pdf", "run pandoc.sh");
-    const pandoc_exe = b.addRunArtifact(exe);
+    const pandoc_exe = b.addRunArtifact(pandoc_sh);
     if (b.args) |args| {
         pandoc_exe.addArgs(args);
     }
@@ -105,7 +106,7 @@ pub fn build(b: *std.Build) !void {
     const docs_install = b.addInstallDirectory(.{
         .install_dir = .prefix,
         .install_subdir = "docs",
-        .source_dir = exe.getEmittedDocs(),
+        .source_dir = pandoc_sh.getEmittedDocs(),
     });
     docs_step.dependOn(&docs_install.step);
 
@@ -126,159 +127,81 @@ pub fn build(b: *std.Build) !void {
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_unit_tests.step);
 
-    const web_step = b.step("web", "Build the policy center");
-    web_step.makeFn = build_web;
-    // web_step.dependOn(pandoc_step);
     const pdf_step = b.step("pdfs", "Build pdfs directly from the build script");
-    try build_pdfs(b, pdf_step, exe);
-}
 
-const MyStep = struct {
-    step: std.Build.Step,
-    my_option: bool,
-};
-//BUG: This is not deploying to zig-out
-fn build_web(step: *std.Build.Step, _: std.Build.Step.MakeOptions) !void {
-    const b = step.owner;
+    const policy_dir = "content/policies";
     const wf = b.addWriteFiles();
 
-    const zola_step = std.Build.Step.Run.create(b, "Zola");
-    step.dependOn(&zola_step.step);
-    zola_step.addArgs(&.{ "zola", "build" });
-    _ = wf.addCopyDirectory(b.path("public"), "", .{ .include_extensions = &.{"pdf"} });
-    wf.step.dependOn(&zola_step.step);
-    const a = b.addInstallDirectory(.{
-        .install_dir = .prefix,
-        .source_dir = wf.getDirectory(),
-        .install_subdir = "web",
+    var dir = try std.fs.cwd().openDir(policy_dir, .{
+        .iterate = true,
+        .access_sub_paths = true,
     });
-    a.step.dependOn(&wf.step);
-    step.dependOn(&a.step);
-}
+    defer dir.close();
 
-fn build_pdfs(b: *std.Build, step: *std.Build.Step, exe: *std.Build.Step.Compile) !void {
-    const wf = b.addWriteFiles();
+    var walker = try dir.walk(b.allocator);
+    defer walker.deinit();
 
-    const markdown_files = b.run(&.{ "git", "ls-files", "content/policies/*.md" });
-    var lines = std.mem.tokenizeScalar(u8, markdown_files, '\n');
+    while (try walker.next()) |entry| {
+        if (entry.kind == .file and std.mem.endsWith(u8, entry.path, ".md")) {
+            const base_name = std.fs.path.basename(entry.path);
+            if (std.mem.eql(u8, base_name, "_index.md")) continue;
 
-    std.fs.cwd().makeDir(".tmp") catch |e| {
-        if (e != error.PathAlreadyExists) return e;
-    };
+            const input_path = b.pathJoin(&.{ policy_dir, entry.path });
+            const input = b.path(input_path);
 
-    _ = wf.addCopyDirectory(b.path(".tmp"), "", .{ .include_extensions = &.{"pdf"} });
+            // Step 2: Run pandoc wrapper
+            const run_wrapper = b.addRunArtifact(pandoc_sh);
+            run_wrapper.addArgs(&.{
+                "--color", "FFFFFF",
+                "--org",   "SC2",
+                "--root",  "./",
+            });
+            run_wrapper.addArg("--logo");
+            run_wrapper.addFileArg(b.path("static/logo.png"));
+            run_wrapper.addArg("--input");
+            run_wrapper.addFileArg(input);
+            run_wrapper.addArg("--output");
+            run_wrapper.expectExitCode(0);
+            _ = run_wrapper.captureStdErr();
+            const pdf_dir = run_wrapper.addOutputDirectoryArg(base_name);
+            if (is_draft) run_wrapper.addArg("-d");
+            if (is_redact) run_wrapper.addArg("-r");
 
-    var run_cmds = Array(*std.Build.Step).init(b.allocator);
-    defer run_cmds.deinit();
+            const inst = b.addInstallDirectory(.{
+                .install_dir = .prefix,
+                .source_dir = pdf_dir,
 
-    while (lines.next()) |file_path| {
-        if (std.mem.endsWith(u8, file_path, "_index.md")) continue;
-
-        var run_cmd = b.addRunArtifact(exe);
-        run_cmd.addArgs(&.{
-            "--color", "FFFFFF",
-            "--org",   "SC2",
-            "--root",  "./",
-        });
-        run_cmd.addArg("--logo");
-        run_cmd.addFileArg(b.path("static/logo.png"));
-        run_cmd.addArg("-i");
-        run_cmd.addFileArg(b.path(file_path));
-        run_cmd.addArg("-o");
-        _ = run_cmd.addOutputDirectoryArg(".tmp");
-        if (is_draft) run_cmd.addArg("-d");
-        if (is_redact) run_cmd.addArg("-r");
-
-        // wf.step.dependOn(&run_cmd.step);
-        // inst.step.dependOn(&run_cmd.step);
-        try run_cmds.append(&run_cmd.step);
+                .install_subdir = "pdfs",
+            });
+            pdf_step.dependOn(&inst.step);
+            // inst.step.dependOn(&run_wrapper.step);
+            // Step 3: Install the generated PDF
+            _ = wf.addCopyDirectory(
+                pdf_dir.path(b, ""),
+                "", //b.pathJoin(&.{ base_name, base_name }),
+                .{ .include_extensions = &.{"pdf"} },
+            );
+        }
     }
-    for (run_cmds.items) |cmd|
-        wf.step.dependOn(cmd);
+    // const mv = b.addSystemCommand(&.{
+    //     "find",
+    //     ".",
+    //     "-type",
+    //     "f",
+    //     "-name",
+    //     "\"*.pdf\"",
+    //     "-exec",
+    //     "echo",
+    // });
+    // const output = mv.addOutputDirectoryArg("pdfs");
+    // mv.addArg("\\\\;");
+    // mv.setCwd(wf.getDirectory());
 
-    const inst = b.addInstallDirectory(.{
-        .source_dir = wf.getDirectory(),
+    const mkdir = b.addInstallDirectory(.{
         .install_dir = .prefix,
         .install_subdir = "pdfs",
+        .source_dir = wf.getDirectory(),
+        .include_extensions = &.{"pdf"},
     });
-    step.dependOn(&inst.step);
-}
-fn cut_prefix(text: []const u8, prefix: []const u8) ?[]const u8 {
-    if (std.mem.startsWith(u8, text, prefix)) return text[prefix.len..];
-    return null;
-}
-
-fn cut_suffix(text: []const u8, suffix: []const u8) ?[]const u8 {
-    if (std.mem.endsWith(u8, text, suffix)) return text[0 .. text.len - suffix.len];
-    return null;
-}
-fn build_pdf_from_markdown(b: *std.Build, path: std.Build.LazyPath, step: *std.Build.Step) !std.Build.LazyPath {
-    const title = b.fmt("Run pandoc for {s}", .{cut_prefix(path.getDisplayName(), "content/policies/").?});
-    const res_path = b.fmt("--resource-path={s}", .{path.dirname().getPath(b)});
-    const data_path = b.fmt("--data-dir={s}", .{try std.fs.cwd().realpathAlloc(b.allocator, ".")});
-    const header = b.fmt("header-right=\\includegraphics[width=2cm,height=2cm]{{{s}}}", .{logo});
-    const footer = b.fmt("footer-left={s} \\textcopyright {s}", .{ org, year });
-    const title_logo = b.fmt("titlepage-logo={s}", .{logo});
-    const inst = b.fmt("institution=\"{s}\"", .{org});
-    const col = b.fmt("titlepage-rule-color={s}", .{color});
-
-    const contents = try readLazyPathToMemory(b, path);
-    const str = Array(u8){
-        .allocator = b.allocator,
-        .items = contents,
-        .capacity = contents.len,
-    };
-    // defer str.deinit();
-    // std.debug.print("{any}\n", .{std.unicode.utf8ValidateSlice(str.items)});
-
-    const pandoc_step = std.Build.Step.Run.create(b, title);
-    step.dependOn(&pandoc_step.step);
-    // try u.replace_org(&str, org, u.DummyProgress{});
-    // try u.replace_mermaid(&str, u.DummyProgress{});
-    pandoc_step.setStdIn(.{ .bytes = str.items });
-
-    pandoc_step.addArg("pandoc");
-    pandoc_step.addPathDir(".devbox/nix/profile/default/bin/");
-    pandoc_step.addArgs(&.{ "-V", "footer-center=Confidental" });
-    pandoc_step.addArgs(&.{ "-V", header });
-    pandoc_step.addArgs(&.{ "-V", footer });
-    pandoc_step.addArgs(&.{ "-V", title_logo });
-    pandoc_step.addArgs(&.{ "-V", inst });
-    pandoc_step.addArgs(&.{ "-V", col });
-    pandoc_step.addArgs(&.{ "-V", "papersize=letter" });
-    pandoc_step.addArgs(&.{ "-V", "titlepage=true" });
-    pandoc_step.addArgs(&.{ "-V", "toc=true" });
-    pandoc_step.addArgs(&.{ "-V", "toc-own-page=true" });
-    pandoc_step.addArgs(&.{ "-V", "toc-depth=3" });
-    pandoc_step.addArgs(&.{ "-V", "logo-width=6cm" });
-    pandoc_step.addArgs(&.{ "-V", "table-use-row-colors=true" });
-    pandoc_step.addArgs(&.{ "-F", "mermaid-filter" });
-    pandoc_step.addArgs(&.{ "--template", "eisvogel" });
-    pandoc_step.addArgs(&.{
-        res_path,
-        data_path,
-        "--from=markdown",
-        "--to=pdf",
-        "--webtex",
-        "--listings",
-        "--pdf-engine=xelatex",
-    });
-    if (is_draft) {
-        pandoc_step.addArgs(&.{ "-V", "page-background=static/draft.png" });
-        pandoc_step.addArgs(&.{ "-V", "page-background-opacity=0.8" });
-    }
-    // pandoc_step.addFileArg(path);
-
-    return pandoc_step.captureStdOut();
-}
-pub fn readLazyPathToMemory(
-    b: *std.Build,
-    lazy_path: std.Build.LazyPath,
-) ![]u8 {
-
-    // Open and read the file as usual
-    var file = try std.fs.cwd().openFile(lazy_path.getPath(b), .{});
-    defer file.close();
-
-    return try file.readToEndAlloc(b.allocator, 100_000_000);
+    pdf_step.dependOn(&mkdir.step);
 }

--- a/build.zig
+++ b/build.zig
@@ -47,6 +47,23 @@ pub fn build(b: *std.Build) !void {
         .optimize = optimize,
     });
 
+    const web_build = b.addSystemCommand(&.{
+        "zola",
+        "build",
+        "--force",
+    });
+    if (draft_option) web_build.addArg("--drafts");
+    if (optimize != .Debug) web_build.addArg("--minify");
+    web_build.addArg("-o");
+    const web_output = web_build.addOutputDirectoryArg("public");
+    const web_inst = b.addInstallDirectory(.{
+        .install_dir = .prefix,
+        .source_dir = web_output,
+        .install_subdir = "public",
+    });
+    const web_step = b.step("web", "Build website from zola");
+    web_step.dependOn(&web_inst.step);
+
     // the executable from your call to exe_mod.addExecutable
     if (target.result.os.tag != .windows) {
         const zap = b.dependency("zap", .{
@@ -71,10 +88,10 @@ pub fn build(b: *std.Build) !void {
             run_server.addArgs(args);
         }
 
-        const serve_step = b.step("serve", "Serve the zola output");
+        const serve_step = b.step("preview", "Serve the zola output");
         serve_step.dependOn(&run_server.step);
     } else {
-        _ = b.step("serve", "Serve the zola output (Not available on Windows. Does nothing.)");
+        _ = b.step("preview", "Serve the zola output (Not available on Windows. run `zola preview` instead.)");
     }
     // the executable from your call to b.addExecutable(...)
 
@@ -216,6 +233,7 @@ pub fn build(b: *std.Build) !void {
     });
     pdf_step.dependOn(&mkdir.step);
 
-    b.default_step.dependOn(pdf_step);
     b.default_step.dependOn(report_step);
+    b.default_step.dependOn(pdf_step);
+    b.default_step.dependOn(web_step);
 }

--- a/build.zig
+++ b/build.zig
@@ -16,6 +16,7 @@ pub fn build(b: *std.Build) !void {
     is_draft = draft_option;
     const redact_option = b.option(bool, "redact", "Produce pdfs with redacted information") orelse false;
     is_redact = redact_option;
+    const policy_dir = "content/policies";
 
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
@@ -92,8 +93,7 @@ pub fn build(b: *std.Build) !void {
         .root_module = pandoc_sh_mod,
         .name = "pandoc_sh",
     });
-    const wrapper_exe = b.addInstallArtifact(pandoc_sh, .{});
-    _ = wrapper_exe; // autofix
+
     var pandoc_step = b.step("pdf", "run pandoc.sh");
     const pandoc_exe = b.addRunArtifact(pandoc_sh);
     if (b.args) |args| {
@@ -120,6 +120,31 @@ pub fn build(b: *std.Build) !void {
     test_module.addImport("yaml", yaml.module("yaml"));
     test_module.addImport("mvzr", mvzr.module("mvzr"));
 
+    const policy_report = b.addExecutable(.{
+        .name = "policy_report",
+        .target = target,
+        .optimize = .ReleaseFast,
+        .root_source_file = b.path("src/control_report.zig"),
+    });
+    policy_report.root_module.addImport("clap", clap.module("clap"));
+    policy_report.root_module.addImport("yaml", yaml.module("yaml"));
+    policy_report.root_module.addImport("tomlz", tomlz.module("tomlz"));
+
+    const run_policy_report = b.addRunArtifact(policy_report);
+    run_policy_report.addArg("--controls_file");
+    run_policy_report.addFileArg(b.path("templates/opencontrols/standards/SCF.json"));
+    run_policy_report.addArg("--policy_root");
+    run_policy_report.addDirectoryArg(b.path(policy_dir));
+    const policy_report_output = run_policy_report.captureStdOut();
+    const policy_report_inst = b.addInstallFileWithDir(
+        policy_report_output,
+        .prefix,
+        "policy_report.json",
+    );
+
+    const report_step = b.step("reports", "Run reports");
+    report_step.dependOn(&policy_report_inst.step);
+
     const unit_tests = b.addTest(.{
         .root_module = test_module,
     });
@@ -129,7 +154,6 @@ pub fn build(b: *std.Build) !void {
 
     const pdf_step = b.step("pdfs", "Build pdfs directly from the build script");
 
-    const policy_dir = "content/policies";
     const wf = b.addWriteFiles();
 
     var dir = try std.fs.cwd().openDir(policy_dir, .{
@@ -183,19 +207,6 @@ pub fn build(b: *std.Build) !void {
             );
         }
     }
-    // const mv = b.addSystemCommand(&.{
-    //     "find",
-    //     ".",
-    //     "-type",
-    //     "f",
-    //     "-name",
-    //     "\"*.pdf\"",
-    //     "-exec",
-    //     "echo",
-    // });
-    // const output = mv.addOutputDirectoryArg("pdfs");
-    // mv.addArg("\\\\;");
-    // mv.setCwd(wf.getDirectory());
 
     const mkdir = b.addInstallDirectory(.{
         .install_dir = .prefix,
@@ -204,4 +215,7 @@ pub fn build(b: *std.Build) !void {
         .include_extensions = &.{"pdf"},
     });
     pdf_step.dependOn(&mkdir.step);
+
+    b.default_step.dependOn(pdf_step);
+    b.default_step.dependOn(report_step);
 }

--- a/build.zig
+++ b/build.zig
@@ -215,7 +215,7 @@ pub fn build(b: *std.Build) !void {
                 .install_subdir = "pdfs",
             });
             pdf_step.dependOn(&inst.step);
-            // inst.step.dependOn(&run_wrapper.step);
+            inst.step.dependOn(&run_wrapper.step);
             // Step 3: Install the generated PDF
             _ = wf.addCopyDirectory(
                 pdf_dir.path(b, ""),

--- a/content/policies/security/access-control.md
+++ b/content/policies/security/access-control.md
@@ -48,15 +48,15 @@ Each user's or workforce member's password must meet the criteria set forth in t
 
 ### Automatic Lock
 
-Servers, workstations, or other computer systems containing PII repositories must employ inactivity timers or automatic logoff mechanisms as described in the [ITSP]({{< ref "/docs/isms/itsp.md#automatic-lockout-policy" >}}).
+Servers, workstations, or other computer systems containing PII repositories must employ inactivity timers or automatic logoff mechanisms as described in the [Application Security Policy](@/policies/security/application_security.md).
 
 ### Encryption and Decryption of PII maintained on internal databases
 
-PII at rest and in transit will be escrypted as described in the [ITSP]({{< ref "/docs/isms/itsp.md#encryption-and-decryption-policy" >}}).
+PII at rest and in transit will be escrypted as described in the [Application Security Policy](@/policies/security/application_security.md).
 
 ### Firewall Use and Remote Access
 
-Firewall and remote access must be configured and managed according to the guidelines specified in the [ITSP]({{< ref "/docs/isms/itsp.md#firewall-and-remote-access-policy" >}}). This includes ensuring that all remote access connections are authenticated and encrypted, and that firewalls are properly configured to protect PII from unauthorized access.
+Firewall and remote access must be configured and managed according to the guidelines specified in the [Application Security Policy](@/policies/security/application_security.md). This includes ensuring that all remote access connections are authenticated and encrypted, and that firewalls are properly configured to protect PII from unauthorized access.
 
 ## Access Revocation
 

--- a/content/policies/security/access-control.md
+++ b/content/policies/security/access-control.md
@@ -52,7 +52,7 @@ Servers, workstations, or other computer systems containing PII repositories mus
 
 ### Encryption and Decryption of PII maintained on internal databases
 
-PII at rest and in transit will be escrypted as described in the [Application Security Policy](@/policies/security/application_security.md).
+PII at rest and in transit will be encrypted as described in the [Application Security Policy](@/policies/security/application_security.md).
 
 ### Firewall Use and Remote Access
 

--- a/src/control_report.zig
+++ b/src/control_report.zig
@@ -124,7 +124,8 @@ pub fn report(self: *Self, policy_root: []const u8) ![]u8 {
 
         try ret.appendSlice(line);
     }
-    _ = ret.pop();
+    if (ret.items.len > 1)
+        _ = ret.pop();
     try ret.appendSlice("}");
     return try ret.toOwnedSlice();
 }

--- a/src/control_report.zig
+++ b/src/control_report.zig
@@ -5,7 +5,7 @@ const tst = std.testing;
 const math = std.math;
 const Yaml = @import("yaml").Yaml;
 const FM = @import("frontmatter.zig");
-
+const clap = @import("clap");
 const Self = @This();
 
 contents: []u8,
@@ -117,12 +117,15 @@ pub fn report(self: *Self, policy_root: []const u8) ![]u8 {
     var p2 = prog.start("Generating Report", self.map.values().len);
     defer p2.end();
     var iter = self.map.iterator();
+    try ret.appendSlice("{");
     while (iter.next()) |c| {
-        const line = try std.fmt.allocPrint(a, "{s}: {}\n", .{ c.key_ptr.*, c.value_ptr.found });
+        const line = try std.fmt.allocPrint(a, "\"{s}\": {},", .{ c.key_ptr.*, c.value_ptr.found });
         defer a.free(line);
 
         try ret.appendSlice(line);
     }
+    _ = ret.pop();
+    try ret.appendSlice("}");
     return try ret.toOwnedSlice();
 }
 
@@ -141,3 +144,47 @@ const Control = struct {
     description: []const u8,
     found: bool = false,
 };
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    var arena = std.heap.ArenaAllocator.init(gpa.allocator());
+    defer arena.deinit();
+
+    const alloc = arena.allocator();
+    const params = comptime clap.parseParamsComptime(
+        \\-h, --help             Display this help and exit.
+        \\--controls_file <str>  Controls file to report against
+        \\--policy_root <str>    Policy root directory
+    );
+    var diag = clap.Diagnostic{};
+    var res = clap.parse(clap.Help, &params, clap.parsers.default, .{
+        .diagnostic = &diag,
+        .allocator = alloc,
+    }) catch |err| {
+        // Report useful error and exit.
+        diag.report(std.io.getStdErr().writer(), err) catch {};
+        return err;
+    };
+    defer res.deinit();
+    if (res.args.help != 0) {
+        std.debug.print(
+            \\SC2 Policy Report
+            \\Returns a json of controls' presence in the policies
+        , .{});
+        return clap.help(std.io.getStdErr().writer(), clap.Help, &params, .{});
+    }
+    var rep = try init(alloc, res.args.controls_file orelse return error.NoControlFile);
+    defer rep.deinit();
+
+    const stdout_file = std.io.getStdOut().writer();
+    var bw = std.io.bufferedWriter(stdout_file);
+    const stdout = bw.writer();
+
+    const r = try rep.report(res.args.policy_root orelse return error.NoPolicyRoot);
+
+    try stdout.print("{s}", .{r});
+
+    try bw.flush(); // Don't forget to flush!
+
+}

--- a/src/pandoc.zig
+++ b/src/pandoc.zig
@@ -246,6 +246,8 @@ pub fn process_md_file(
     defer dir.close();
     var file = try dir.openFile(md.path, .{ .mode = .read_only });
     defer file.close();
+    var build = try std.fs.cwd().openDir(global_config.build_dir.?, .{});
+    defer build.close();
 
     const raw = try file.readToEndAlloc(a, 100_000_000);
     var contents = Array(u8){
@@ -266,17 +268,17 @@ pub fn process_md_file(
     defer fm.deinit(a);
 
     const tmp_file = std.fs.path.basename(md.path);
-    const tmp = std.fs.cwd().createFile(tmp_file, std.fs.File.CreateFlags{ .exclusive = true }) catch |e| blk: {
+    const tmp = build.createFile(tmp_file, std.fs.File.CreateFlags{ .exclusive = true }) catch |e| blk: {
         if (e == error.PathAlreadyExists) {
-            std.fs.cwd().deleteFile(tmp_file) catch unreachable;
-            break :blk try std.fs.cwd().createFile(tmp_file, std.fs.File.CreateFlags{ .exclusive = true });
+            build.deleteFile(tmp_file) catch unreachable;
+            break :blk try build.createFile(tmp_file, std.fs.File.CreateFlags{ .exclusive = true });
         }
         return e;
     };
 
     defer {
         tmp.close();
-        std.fs.cwd().deleteFile(tmp_file) catch unreachable;
+        build.deleteFile(tmp_file) catch unreachable;
     }
     try tmp.writeAll(contents.items);
 
@@ -286,7 +288,7 @@ pub fn process_md_file(
     const res_path = try std.fmt.allocPrint(a, "--resource-path={s}", .{basedir});
     try local.append(res_path);
 
-    try local.append(try a.dupe(u8, tmp_file));
+    try local.append(try std.fs.path.join(a, &.{ global_config.build_dir.?, tmp_file }));
 
     const out = try fm.filename(a);
     std.mem.replaceScalar(u8, out, ' ', '_');


### PR DESCRIPTION
This pull request introduces several updates to the `build.zig` file and related components to improve the build system, streamline PDF generation, and enhance policy reporting. Key changes include the addition of new build steps for web content and policy reporting, updates to the handling of markdown files for PDF generation, and integration of `clap` for command-line argument parsing in the policy report executable.

### Build System Enhancements:
* Added a new build step (`web_step`) to generate the website using `zola` with support for drafts and minification, and set up installation of the generated content to the `public` directory.
* Renamed the "serve" step to "preview" for clarity and updated its description to reflect platform-specific behavior.

### Policy Reporting Improvements:
* Introduced a new executable (`policy_report`) to generate JSON reports on policy compliance using `clap` for command-line argument parsing. Added steps to install the generated report as `policy_report.json`. [[1]](diffhunk://#diff-f87bb3596894756629bc39d595fb18d479dc4edf168d93a911cadcb060f10fccR140-R238) [[2]](diffhunk://#diff-369ec687f077ad92260b92006fbd4c0f43d37cb865ac22efbf81038aa56701deR147-R190)

### PDF Generation Updates:
* Refactored the PDF generation process to iterate over markdown files in the `content/policies` directory, using `pandoc_sh` to generate PDFs directly. Removed deprecated methods and simplified installation of the generated PDFs.

### Code Simplifications:
* Updated `process_md_file` in `src/pandoc.zig` to use the `build_dir` directory for temporary file creation and deletion, improving modularity and reducing reliance on the current working directory. [[1]](diffhunk://#diff-f7ab9830110da62dd5ebab825a0cedb28c6565d161d4251817453a6ce3c42553R249-R250) [[2]](diffhunk://#diff-f7ab9830110da62dd5ebab825a0cedb28c6565d161d4251817453a6ce3c42553L269-R281) [[3]](diffhunk://#diff-f7ab9830110da62dd5ebab825a0cedb28c6565d161d4251817453a6ce3c42553L289-R291)

### Documentation Updates:
* Updated references in `content/policies/security/access-control.md` to point to the `Application Security Policy` instead of the deprecated `ITSP`.