### PR TITLE
Link PDFs back to the base_url

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -18,7 +18,9 @@ pub fn build(b: *std.Build) !void {
     is_draft = draft_option;
     const redact_option = b.option(bool, "redact", "Produce pdfs with redacted information") orelse false;
     is_redact = redact_option;
+
     const policy_dir = "content/policies";
+    const base_url = "https://security.sc2.in";
 
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
@@ -195,9 +197,10 @@ pub fn build(b: *std.Build) !void {
             // Step 2: Run pandoc wrapper
             const run_wrapper = b.addRunArtifact(pandoc_sh);
             run_wrapper.addArgs(&.{
-                "--color", "FFFFFF",
-                "--org",   "SC2",
-                "--root",  "./",
+                "--color",    "FFFFFF",
+                "--org",      "SC2",
+                "--root",     "./",
+                "--base_url", base_url,
             });
             run_wrapper.addArg("--logo");
             run_wrapper.addFileArg(b.path("static/logo.png"));

--- a/content/policies/test_policy.md
+++ b/content/policies/test_policy.md
@@ -48,8 +48,10 @@ C --> D
 ## Zola link replacement
 
 [policy](@/policies/aeip.md)
-[directory](@/policies/_index.md)
-<!-- [passthrough](@/news/privacy-policy-update.jpg) -->
+
+[section](@/policies/_index.md)
+
+[directory](@/policies/incident/digital-forensics/index.md)
 
 ## Redaction
 

--- a/content/policies/test_policy.md
+++ b/content/policies/test_policy.md
@@ -45,6 +45,12 @@ B -- No --> D[End]
 C --> D
 {% end %}
 
+## Zola link replacement
+
+[policy](@/policies/aeip.md)
+[directory](@/policies/_index.md)
+<!-- [passthrough](@/news/privacy-policy-update.jpg) -->
+
 ## Redaction
 
 {% redact() %}

--- a/src/control_report.zig
+++ b/src/control_report.zig
@@ -135,7 +135,8 @@ test {
     defer r.deinit();
 
     const out = try r.report("content/policies");
-    std.debug.print("{s}", .{out});
+    _ = out; // autofix
+    // std.debug.print("{s}", .{out});
 }
 
 const Control = struct {

--- a/src/pandoc.zig
+++ b/src/pandoc.zig
@@ -24,6 +24,7 @@ var global_args: Array([]u8) = undefined;
 pub var global_config: Config = .{};
 
 pub const Config = struct {
+    base_url: ?[]const u8 = null,
     org: ?[]const u8 = null,
     logo_path: ?[]const u8 = null,
     color: ?[]const u8 = null,
@@ -84,6 +85,7 @@ pub fn main() !void {
         \\--logo <str>           Path to logo file
         \\--color <str>          Accent color to use
         \\--root <str>           Project root directory
+        \\--base_url <str>       Base url for the project
     );
     var diag = clap.Diagnostic{};
     var res = clap.parse(clap.Help, &params, clap.parsers.default, .{
@@ -122,6 +124,10 @@ pub fn main() !void {
     if (res.args.root) |c| {
         panlog.info("Project Root: {s}\n", .{c});
         global_config.root = c;
+    } else return error.ProjectRootNotProvided;
+    if (res.args.base_url) |c| {
+        panlog.info("Base URL: {s}\n", .{c});
+        global_config.base_url = c;
     } else return error.ProjectRootNotProvided;
     if (res.args.draft != 0) {
         panlog.info("Draft mode enabled\n", .{});
@@ -263,7 +269,7 @@ pub fn process_md_file(
     defer local.deinit();
 
     try u.replace_org(&contents, global_config.org.?);
-    try u.replace_zola_at(&contents);
+    try u.replace_zola_at(&contents, global_config.base_url.?);
     try u.replace_mermaid(&contents);
     try u.redact(&contents, global_config.redact);
 

--- a/src/pandoc.zig
+++ b/src/pandoc.zig
@@ -128,7 +128,7 @@ pub fn main() !void {
     if (res.args.base_url) |c| {
         panlog.info("Base URL: {s}\n", .{c});
         global_config.base_url = c;
-    } else return error.ProjectRootNotProvided;
+    } else return error.BaseUrlNotProvided;
     if (res.args.draft != 0) {
         panlog.info("Draft mode enabled\n", .{});
         global_config.is_draft = true;

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -134,17 +134,38 @@ pub fn replace_org(txt: *Array(u8), with: []const u8) !void {
     txt.* = new;
 }
 
-/// Replaces all instances of the [...](@/...) links inthe markdown text with the path relative to content
-pub fn replace_zola_at(txt: *Array(u8)) !void {
-    const at: mvzr.Regex = mvzr.compile("\\]\\(@/").?;
-
+/// Replaces all instances of the [...](@/...) links in the markdown text with the base_url
+/// Example: [Privacy](@/policies/privacy-policy.md) -> [Privacy](https://security.sc2.in/privacy-policy.html)
+/// Example: [Acceptable Use](@/policies/aup/) -> [Acceptable Use](https://security.sc2.in/aup/)
+/// Example: [Image passthrough](@/policies/aup/image.png) -> [Image passthrough](https://security.sc2.in/aup/image.png)
+pub fn replace_zola_at(txt: *Array(u8), base_url: []const u8) !void {
+    const at: mvzr.Regex = mvzr.compile("\\]\\(@/.+?\\)").?;
     if (!at.isMatch(txt.items)) return;
 
     var new = try txt.clone();
 
     var iter = at.iterator(txt.items);
+
     while (iter.next()) |match| {
-        try new.replaceRange(match.start, match.slice.len, "](content/");
+        const ref = match.slice[4 .. match.slice.len - 1];
+
+        const file = if (std.mem.endsWith(u8, ref, "/_index.md"))
+            try txt.allocator.dupe(u8, ref[0 .. ref.len - 9])
+        else if (std.mem.endsWith(u8, ref, "/index.md"))
+            try txt.allocator.dupe(u8, ref[0 .. ref.len - 8])
+        else if (std.mem.endsWith(u8, ref, ".md"))
+            try std.fmt.allocPrint(txt.allocator, "{s}.html", .{ref[0 .. ref.len - 3]})
+        else
+            try txt.allocator.dupe(u8, ref);
+        defer txt.allocator.free(file);
+
+        const link = try std.fmt.allocPrint(txt.allocator, "]({s}/{s})", .{
+            base_url,
+            file,
+        });
+        defer txt.allocator.free(link);
+        try new.replaceRange(match.start, match.slice.len, link);
+
         iter = at.iterator(new.items);
     }
     txt.deinit();
@@ -157,13 +178,19 @@ test "replace_zola_at" {
     var arr = Array(u8).init(allocator);
     defer arr.deinit();
     try arr.appendSlice(
-        \\[some link](@/policies/privacy)
+        \\[some section](@/policies/privacy/_index.md)
+        \\[some dir](@/policies/privacy/index.md)
+        \\[some link](@/policies/aup.md)
+        \\[an image](@/policies/image.png)
     );
 
-    try replace_zola_at(&arr);
+    try replace_zola_at(&arr, "https://example.com");
 
     const expected =
-        \\[some link](content/policies/privacy)
+        \\[some section](https://example.com/policies/privacy/)
+        \\[some dir](https://example.com/policies/privacy/)
+        \\[some link](https://example.com/policies/aup.html)
+        \\[an image](https://example.com/policies/image.png)
     ;
     try tst.expectEqualStrings(expected, arr.items);
 }
@@ -457,7 +484,7 @@ test "Redaction" {
 
     try ts.appendSlice(t);
     try redact(&ts, true);
-    std.debug.print("{s}\n", .{ts.items});
+    // std.debug.print("{s}\n", .{ts.items});
     try tst.expectEqualStrings(&expected, ts.items);
 
     var t2 = Array(u8).init(tst.allocator);

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -135,9 +135,9 @@ pub fn replace_org(txt: *Array(u8), with: []const u8) !void {
 }
 
 /// Replaces all instances of the [...](@/...) links in the markdown text with the base_url
-/// Example: [Privacy](@/policies/privacy-policy.md) -> [Privacy](https://security.sc2.in/privacy-policy.html)
-/// Example: [Acceptable Use](@/policies/aup/) -> [Acceptable Use](https://security.sc2.in/aup/)
-/// Example: [Image passthrough](@/policies/aup/image.png) -> [Image passthrough](https://security.sc2.in/aup/image.png)
+/// Example: [Privacy](@/policies/privacy-policy.md) -> [Privacy](https://security.sc2.in/policies/privacy-policy.html)
+/// Example: [Acceptable Use](@/policies/aup/) -> [Acceptable Use](https://security.sc2.in/policies/aup/)
+/// Example: [Image passthrough](@/policies/aup/image.png) -> [Image passthrough](https://security.sc2.in/policies/aup/image.png)
 pub fn replace_zola_at(txt: *Array(u8), base_url: []const u8) !void {
     const at: mvzr.Regex = mvzr.compile("\\]\\(@/.+?\\)").?;
     if (!at.isMatch(txt.items)) return;


### PR DESCRIPTION
This pull request introduces changes to improve link handling, add a new configuration option, and clean up debugging output in the codebase. The most significant updates include adding support for replacing Zola-style links with fully qualified URLs, introducing a `base_url` configuration parameter, and updating related tests and logic.

### Improvements to link handling:
* Updated the `replace_zola_at` function in `src/utils.zig` to replace Zola-style links (e.g., `[@/policies/privacy]`) with fully qualified URLs based on the `base_url` configuration. This includes handling special cases like `_index.md` and `.md` files.
* Modified the `process_md_file` function in `src/pandoc.zig` to pass the `base_url` to the `replace_zola_at` function.

### New configuration option:
* Added a `base_url` parameter to the global configuration in `src/pandoc.zig`, allowing users to specify the base URL for their project. This parameter is now parsed from command-line arguments and logged during execution. [[1]](diffhunk://#diff-f7ab9830110da62dd5ebab825a0cedb28c6565d161d4251817453a6ce3c42553R27) [[2]](diffhunk://#diff-f7ab9830110da62dd5ebab825a0cedb28c6565d161d4251817453a6ce3c42553R88) [[3]](diffhunk://#diff-f7ab9830110da62dd5ebab825a0cedb28c6565d161d4251817453a6ce3c42553R128-R131)

### Test updates:
* Enhanced the test for `replace_zola_at` in `src/utils.zig` to validate the new functionality for generating fully qualified URLs.

### Code cleanup:
* Replaced a debugging print statement in `src/control_report.zig` with a no-op assignment to suppress output.
* Commented out a debugging print statement in the redaction test in `src/utils.zig`.

### Build system updates:
* Added a `base_url` variable to `build.zig` and included it as an argument in the `run_wrapper` command. [[1]](diffhunk://#diff-f87bb3596894756629bc39d595fb18d479dc4edf168d93a911cadcb060f10fccR21-R23) [[2]](diffhunk://#diff-f87bb3596894756629bc39d595fb18d479dc4edf168d93a911cadcb060f10fccR203)