### PR TITLE
Validate report output

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -200,7 +200,7 @@ pub fn build(b: *std.Build) !void {
         const policy_report_output = run_policy_report.captureStdOut();
         const policy_report_inst = b.addInstallFileWithDir(
             policy_report_output,
-            .prefix,
+            .{ .custom = "reports" },
             "policy_report.json",
         );
 

--- a/build.zig
+++ b/build.zig
@@ -10,7 +10,7 @@ const ReportType = @import("src/control_report.zig").Report;
 pub fn build(b: *std.Build) !void {
     const draft_option = b.option(bool, "draft", "Produce pdfs with a draft watermark") orelse false;
     const redact_option = b.option(bool, "redact", "Produce pdfs with redacted information") orelse false;
-    const report_option = b.option(ReportType, "report", "Type of report to run") orelse .ISO;
+    const report_option = b.option(ReportType, "report", "Type of report to run") orelse .SCF;
 
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
@@ -204,8 +204,9 @@ pub fn build(b: *std.Build) !void {
             "policy_report.json",
         );
 
-        const report_step = b.step("reports", "Run reports");
+        var report_step = b.step("reports", "Run reports");
         report_step.dependOn(&policy_report_inst.step);
+        b.default_step.dependOn(report_step);
     }
 
     {

--- a/flake.nix
+++ b/flake.nix
@@ -109,6 +109,9 @@
             if [ -d "$out/public" ]; then
               echo "✓ Site generated"
             fi
+            if [ -d "$out/reports" ]; then
+              echo "✓ Reports generated"
+            fi
           '';
 
           fixupPhase = ''
@@ -152,6 +155,7 @@
             echo "Build complete. Outputs:"
             echo "  PDFs: $PREFIX/pdfs"
             echo "  Site: $PREFIX/public"
+            echo "  Reports: $PREFIX/reports"
           '';
         };
       in {

--- a/src/config.zig
+++ b/src/config.zig
@@ -57,7 +57,7 @@ pub const Config = struct {
         try writer.print("{s}", .{output});
     }
     pub fn load_config_toml(alloc: Allocator) !Config {
-        conflog.info("Loading config.toml", .{});
+        conflog.debug("Loading config.toml", .{});
         const file = try std.fs.cwd().openFile("config.toml", .{});
         defer file.close();
 

--- a/src/control_report.zig
+++ b/src/control_report.zig
@@ -151,7 +151,7 @@ const Control = struct {
     found: bool = false,
 };
 
-pub const Report = enum(u8) {
+pub const Report = enum {
     SOC2,
     ISO,
     SCF,
@@ -170,7 +170,7 @@ pub fn main() !void {
 
     const params = comptime clap.parseParamsComptime(
         \\-h, --help             Display this help and exit.
-        \\--report Report        Report type to run
+        \\--report <REPORT>      Report type to run
     );
 
     var buffer: [128]u8 = undefined;
@@ -182,10 +182,17 @@ pub fn main() !void {
     const stderr: *std.Io.Writer = &err_writer.interface;
 
     var diag = clap.Diagnostic{};
-    var res = clap.parse(clap.Help, &params, clap.parsers.default, .{
-        .diagnostic = &diag,
-        .allocator = alloc,
-    }) catch |err| {
+    var res = clap.parse(
+        clap.Help,
+        &params,
+        .{
+            .REPORT = clap.parsers.enumeration(Report),
+        },
+        .{
+            .diagnostic = &diag,
+            .allocator = alloc,
+        },
+    ) catch |err| {
         // Report useful error and exit.
         diag.report(stderr, err) catch {};
         return err;
@@ -201,7 +208,7 @@ pub fn main() !void {
     const path = try std.fmt.allocPrint(
         alloc,
         "templates/opencontrols/standards/{s}.json",
-        .{@tagName(@as(Report, @enumFromInt(res.args.report)))},
+        .{@tagName(res.args.report.?)},
     );
     defer alloc.free(path);
     var rep = try init(
@@ -209,7 +216,7 @@ pub fn main() !void {
         path,
     );
     defer rep.deinit();
-
+    std.debug.print("Getting reports from {s}\n", .{config.policy_dir});
     const r = try rep.report(config.policy_dir);
 
     try stdout.print("{s}", .{r});

--- a/src/control_report.zig
+++ b/src/control_report.zig
@@ -205,18 +205,23 @@ pub fn main() !void {
         , .{});
         return clap.help(stderr, clap.Help, &params, .{});
     }
-    const path = try std.fmt.allocPrint(
-        alloc,
-        "templates/opencontrols/standards/{s}.json",
-        .{@tagName(res.args.report.?)},
-    );
+    const path = if (res.args.report) |r| blk: {
+        break :blk try std.fmt.allocPrint(
+            alloc,
+            "templates/opencontrols/standards/{s}.json",
+            .{@tagName(r)},
+        );
+    } else {
+        std.debug.print("No Report specified\n", .{});
+        return error.NoReportSpecified;
+    };
     defer alloc.free(path);
     var rep = try init(
         alloc,
         path,
     );
     defer rep.deinit();
-    std.debug.print("Getting reports from {s}\n", .{config.policy_dir});
+    // std.debug.print("Getting reports from {s}\n", .{config.policy_dir});
     const r = try rep.report(config.policy_dir);
 
     try stdout.print("{s}", .{r});

--- a/src/control_report.zig
+++ b/src/control_report.zig
@@ -7,7 +7,7 @@ const Yaml = @import("yaml").Yaml;
 const FM = @import("frontmatter.zig");
 const clap = @import("clap");
 const Self = @This();
-const BuildConfig = @import("config.zig").BuildConfig;
+const BuildConfig = @import("config.zig").Config;
 
 contents: []u8,
 arena: std.heap.ArenaAllocator,
@@ -114,7 +114,11 @@ pub fn report(self: *Self, policy_root: []const u8) ![]u8 {
     var iter = self.map.iterator();
     try ret.appendSlice(a, "{");
     while (iter.next()) |c| {
-        const line = try std.fmt.allocPrint(a, "\"{s}\": {},", .{ c.key_ptr.*, c.value_ptr.found });
+        const line = try std.fmt.allocPrint(
+            a,
+            "\"{s}\": {},",
+            .{ c.key_ptr.*, c.value_ptr.found },
+        );
         defer a.free(line);
 
         try ret.appendSlice(a, line);
@@ -126,12 +130,17 @@ pub fn report(self: *Self, policy_root: []const u8) ![]u8 {
 }
 
 test {
-    var r = try Self.init(tst.allocator, "templates/opencontrols/standards/SCF.json");
+    var r = try Self.init(
+        tst.allocator,
+        "templates/opencontrols/standards/SCF.json",
+    );
     defer r.deinit();
 
     const out = try r.report("content/policies");
-    _ = out; // autofix
-    // std.debug.print("{s}", .{out});
+    const j = try std.json.parseFromSlice(std.json.Value, tst.allocator, out, .{});
+    defer j.deinit();
+    try tst.expect(j.value.object.count() >= 1239); // test for number of controls read as of 10/2/2025
+    try tst.expect(j.value.object.get("HRS-05").?.bool);
 }
 
 const Control = struct {
@@ -145,6 +154,7 @@ const Control = struct {
 pub const Report = enum(u8) {
     SOC2,
     ISO,
+    SCF,
 };
 
 pub fn main() !void {
@@ -155,20 +165,29 @@ pub fn main() !void {
 
     const alloc = arena.allocator();
 
-    const config = try BuildConfig.load_config_toml(alloc);
+    var config = try BuildConfig.load_config_toml(alloc);
     defer config.deinit(alloc);
 
     const params = comptime clap.parseParamsComptime(
         \\-h, --help             Display this help and exit.
         \\--report Report        Report type to run
     );
+
+    var buffer: [128]u8 = undefined;
+    var output_writer: std.fs.File.Writer = std.fs.File.stdout().writer(&buffer);
+    const stdout: *std.Io.Writer = &output_writer.interface;
+
+    var buffer2: [128]u8 = undefined;
+    var err_writer: std.fs.File.Writer = std.fs.File.stderr().writer(&buffer2);
+    const stderr: *std.Io.Writer = &err_writer.interface;
+
     var diag = clap.Diagnostic{};
     var res = clap.parse(clap.Help, &params, clap.parsers.default, .{
         .diagnostic = &diag,
         .allocator = alloc,
     }) catch |err| {
         // Report useful error and exit.
-        diag.report(std.io.getStdErr().writer(), err) catch {};
+        diag.report(stderr, err) catch {};
         return err;
     };
     defer res.deinit();
@@ -177,19 +196,25 @@ pub fn main() !void {
             \\SC2 Policy Report
             \\Returns a json of controls' presence in the policies
         , .{});
-        return clap.help(std.io.getStdErr().writer(), clap.Help, &params, .{});
+        return clap.help(stderr, clap.Help, &params, .{});
     }
-    var rep = try init(alloc, @tagName(@as(Report, @enumFromInt(res.args.report))));
+    const path = try std.fmt.allocPrint(
+        alloc,
+        "templates/opencontrols/standards/{s}.json",
+        .{@tagName(@as(Report, @enumFromInt(res.args.report)))},
+    );
+    defer alloc.free(path);
+    var rep = try init(
+        alloc,
+        path,
+    );
     defer rep.deinit();
-
-    const stdout_file = std.io.getStdOut().writer();
-    var bw = std.io.bufferedWriter(stdout_file);
-    const stdout = bw.writer();
 
     const r = try rep.report(config.policy_dir);
 
     try stdout.print("{s}", .{r});
 
-    try bw.flush(); // Don't forget to flush!
+    try stdout.flush(); // Don't forget to flush!
+    try stderr.flush(); // Don't forget to flush!
 
 }

--- a/src/test.zig
+++ b/src/test.zig
@@ -8,15 +8,10 @@ const cr = @import("control_report.zig");
 const fm = @import("frontmatter.zig");
 const pandoc = @import("pandoc.zig");
 const config = @import("config.zig").Config;
+const report = @import("control_report.zig");
 
 // TODO
 // - [ ] The reports should generate correctly
-// - [-] The test policy should render in html and pdf correctly
-//   - [x] pdf
-//   - [ ] html
-// - [ ] All configuration options in config.toml should be validated
-//      this requires the same logic that is holding up #45
-// - [x] All frontmatter options should be validated.
 
 const TestConfig =
     \\base_url = "http://localhost:1111"
@@ -34,6 +29,7 @@ test {
     _ = cr;
     _ = fm;
     _ = pandoc;
+    _ = report;
     tst.refAllDeclsRecursive(@This());
 }
 


### PR DESCRIPTION
This pull request introduces several improvements and refactors across the build system, report generation, configuration, and testing modules. The most significant changes include switching the default report type to `SCF`, updating report handling logic and enum values, improving error reporting and output handling, and enhancing the test coverage for report generation. These changes help streamline the report generation workflow, improve diagnostics, and ensure better maintainability and extensibility.

**Build system and report outputs:**
* Changed the default report type in `build.zig` from `.ISO` to `.SCF` to align with current reporting needs.
* Updated the install directory for policy reports to a custom `reports` directory and ensured the reports step is a dependency of the default build step, improving output organization.
* Enhanced output messages in `flake.nix` to indicate when reports are generated and included the new reports directory in the build summary. [[1]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R112-R114) [[2]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R158)

**Report generation and configuration:**
* Refactored the `Report` enum to add `SCF` and remove explicit type (`u8`), and improved command-line parsing and output/error handling in `src/control_report.zig` for better diagnostics and user experience. [[1]](diffhunk://#diff-369ec687f077ad92260b92006fbd4c0f43d37cb865ac22efbf81038aa56701deL145-R157) [[2]](diffhunk://#diff-369ec687f077ad92260b92006fbd4c0f43d37cb865ac22efbf81038aa56701deL158-R197) [[3]](diffhunk://#diff-369ec687f077ad92260b92006fbd4c0f43d37cb865ac22efbf81038aa56701deL180-R230)
* Changed the configuration loading log level from `info` to `debug` for less noisy output during normal operation.
* Fixed the import of `BuildConfig` to `Config` in `src/control_report.zig` for consistency.

**Testing improvements:**
* Expanded the test for SCF report generation to parse the output as JSON and validate the number of controls and a specific control's presence, ensuring correctness of report contents.
* Updated `src/test.zig` to reference the new report module and cleaned up outdated TODO comments. [[1]](diffhunk://#diff-2cbfda33046ae9947067f8b985c07a24126c4be943708b8aff2184e49cbe8609R11-L19) [[2]](diffhunk://#diff-2cbfda33046ae9947067f8b985c07a24126c4be943708b8aff2184e49cbe8609R32)

Closes #72 