### PR TITLE
feat(starter): add starter template with example policies and GitHub Action workflow

### DIFF
--- a/starter/.github/workflows/build.yml
+++ b/starter/.github/workflows/build.yml
@@ -1,0 +1,60 @@
+name: Build Policies
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      draft:
+        description: "Stamp PDFs with DRAFT watermark"
+        required: false
+        default: "false"
+      redact:
+        description: "Redact content inside redaction tags"
+        required: false
+        default: "false"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build policies
+        uses: sc2in/policypress@v1
+        with:
+          config_path: config.toml
+          draft_mode: ${{ github.event.inputs.draft || 'false' }}
+          redact_mode: ${{ github.event.inputs.redact || 'false' }}
+
+      - name: Upload PDFs
+        uses: actions/upload-artifact@v4
+        with:
+          name: policies
+          path: public/pdfs/
+          retention-days: 90
+
+      - name: Upload site
+        uses: actions/upload-pages-artifact@v3
+        if: github.ref == 'refs/heads/main'
+        with:
+          path: public/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/starter/README.md
+++ b/starter/README.md
@@ -1,0 +1,66 @@
+# PolicyPress Starter
+
+A ready-to-use template for managing information security policies with [PolicyPress](https://github.com/sc2in/policypress).
+
+Write policies in Markdown. Push to GitHub. Get a PDF library and a policy website automatically.
+
+## Quick Start
+
+1. **Click "Use this template"** → "Create a new repository"
+2. Edit `config.toml` — set `organization`, `base_url`, and drop your `logo.png` in `static/`
+3. Push to `main` — the action builds your PDFs and deploys your site
+
+That's it.
+
+## GitHub Action
+
+The [`sc2in/policypress`](https://github.com/sc2in/policypress) action handles everything:
+
+```yaml
+- uses: sc2in/policypress@v1
+  with:
+    config_path: config.toml   # path to your config.toml
+    draft_mode: false          # true → DRAFT watermark on all PDFs
+    redact_mode: false         # true → redact {% redact() %}...{% end %} blocks
+```
+
+On every push to `main` it:
+- Compiles all policies to PDF
+- Builds the policy website
+- Deploys to GitHub Pages
+- Uploads PDFs as a build artifact
+
+Draft and redacted builds can be triggered manually via **Actions → Build Policies → Run workflow**.
+
+## Adding a Policy
+
+Copy any `.md` file in `content/policies/` as a starting point. The frontmatter fields that matter:
+
+```yaml
+---
+title: "Policy Name"
+extra:
+  owner: Team Name
+  last_reviewed: 2025-01-01
+  major_revisions:
+    - date: 2025-01-01
+      description: Initial policy.
+      revised_by: Author
+      approved_by: Approver
+      version: "1.0"
+---
+```
+
+## Shortcodes
+
+| Shortcode | What it does |
+|---|---|
+| `{{ org() }}` | Inserts the organization name from `config.toml` |
+| `{% redact() %}...{% end %}` | Redacts content when `--redact` is active |
+| `{% admonition(type="note") %}...{% end %}` | Callout box (note / tip / warning / important / danger) |
+
+## GitHub Pages Setup
+
+Enable Pages in your repo: **Settings → Pages → Source → GitHub Actions**.
+
+The workflow deploys automatically on every push to `main`.

--- a/starter/config.toml
+++ b/starter/config.toml
@@ -1,0 +1,95 @@
+# The URL your policy site will be published at.
+# Used for internal links and the site's canonical URL.
+base_url = "https://policies.example.com"
+
+# The policypress theme is fetched automatically by the GitHub Action.
+# Do not change this value.
+theme = "policypress"
+
+title = "Policies"
+description = "Information security and compliance policies."
+default_language = "en"
+compile_sass = true
+minify_html = false
+generate_feeds = false
+build_search_index = true
+generate_sitemap = true
+generate_robots_txt = true
+
+[[taxonomies]]
+name = "SCF"
+feed = false
+render = false
+
+[[taxonomies]]
+name = "ISO27001"
+feed = false
+render = false
+
+[[taxonomies]]
+name = "TSC2017"
+feed = true
+render = true
+
+[markdown]
+render_emoji = false
+smart_punctuation = false
+external_links_target_blank = true
+external_links_no_follow = true
+external_links_no_referrer = true
+
+[search]
+index_format = "elasticlunr_json"
+
+[extra]
+# Your organization's name. Used in PDF headers, footers, and policy text
+# wherever the {{ org() }} shortcode appears.
+organization = "Example Corp"
+
+# Logo file under static/. Used on the PDF title page and running header.
+logo = "logo.png"
+
+# Brand color for PDF title page rules and accents. Any hex color.
+pdf_color = "#0e90f3"
+
+# Path to your policies directory, relative to content/.
+policy_dir = "policies/"
+
+# Set to true to redact content inside {% redact() %}...{% end %} blocks
+# by default. Can be overridden per-run with --redact / --no-redact.
+redact = false
+
+# Set to true to stamp all PDFs with a DRAFT watermark by default.
+# Can be overridden per-run with --draft / --no-draft.
+draft = false
+
+# Landing page and navigation
+landing_page = true
+blog = false
+policypress_version = "1"
+
+[extra.author]
+name = "Security Team"
+email = "security@example.com"
+
+[extra.menu]
+logo = "/logo.png"
+
+[[extra.menu.main]]
+title = "Policies"
+section = "policies"
+url = "/policies/"
+weight = 10
+
+[[extra.social]]
+name = "github"
+url = "https://github.com/example"
+
+[extra.frontpage]
+[extra.frontpage.hero]
+title = "Security Policies"
+subtitle = "Information security and compliance policies for our organization."
+
+[extra.frontpage.cta]
+text = "View Policies"
+url = "/policies/"

--- a/starter/content/policies/_index.md
+++ b/starter/content/policies/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Policies"
+weight = 2
+sort_by = "weight"
+insert_anchor_links = "right"
+template = "policies/section.html"
+page_template = "policies/page.html"
++++

--- a/starter/content/policies/access-control.md
+++ b/starter/content/policies/access-control.md
@@ -1,0 +1,111 @@
+---
+title: "Access Control Policy"
+description: "Requirements for granting, managing, and revoking access to systems and data"
+date: 2025-01-01
+weight: 10
+taxonomies:
+  SCF:
+    - IAC-01
+    - IAC-02
+    - IAC-06
+    - IAC-07
+    - IAC-10
+    - IAC-15
+    - IAC-16
+  ISO27001:
+    - A.5.15
+    - A.5.16
+    - A.5.17
+    - A.5.18
+    - A.8.2
+    - A.8.3
+    - A.8.5
+extra:
+  owner: IT / Security
+  last_reviewed: 2025-01-01
+  major_revisions:
+    - date: 2025-01-01
+      description: Initial policy.
+      revised_by: IT / Security
+      approved_by: CEO
+      version: "1.0"
+---
+
+## Purpose and Scope
+
+This policy establishes requirements for controlling access to {{ org() }}'s information systems, applications, and data. Access shall be granted based on the principle of least privilege — users receive only the access required to perform their job duties.
+
+This policy applies to all employees, contractors, and third parties with access to {{ org() }} systems.
+
+## Access Provisioning
+
+Access requests must be submitted through the approved ticketing system and include:
+
+- Business justification
+- System or data being requested
+- Access level required
+- Duration (permanent or time-limited)
+- Approving manager
+
+Access is provisioned only after written approval from the resource owner and the requester's manager.
+
+## Authentication Requirements
+
+| Account Type | Minimum Requirement |
+|---|---|
+| Standard user accounts | Password + MFA |
+| Privileged / admin accounts | Password + MFA + PAM tool |
+| Service accounts | Managed credentials (no shared passwords) |
+| Third-party / vendor accounts | MFA + time-limited access |
+
+Passwords must meet the following minimum requirements:
+
+- 14 characters or longer
+- No reuse of the last 12 passwords
+- Changed immediately upon any suspected compromise
+
+## Privileged Access
+
+Privileged accounts (administrator, root, service accounts with elevated rights) are subject to additional controls:
+
+- Separate privileged account from day-to-day user account
+- All privileged activity logged and reviewed monthly
+- Just-in-time access preferred over standing privilege where technically feasible
+- Annual review of all privileged account holders
+
+## Access Reviews
+
+| Scope | Frequency |
+|---|---|
+| All user access | Quarterly |
+| Privileged access | Monthly |
+| Third-party / vendor access | Monthly |
+| Terminated or transferred users | Within 1 business day |
+
+Access reviews are documented and retained for a minimum of one year.
+
+## Access Revocation
+
+Access must be revoked:
+
+- **Immediately** upon termination (same business day)
+- **Within 48 hours** of a role change that removes the need for access
+- **Immediately** upon any suspected account compromise
+
+HR is responsible for notifying IT of terminations and role changes on the day they occur.
+
+## Remote Access
+
+Remote access to {{ org() }} systems requires:
+
+- Company-managed device or approved BYOD configuration
+- VPN connection for access to internal resources
+- MFA for all remote sessions
+
+## Compliance and Enforcement
+
+Violations of this policy may result in disciplinary action up to and including termination. Access violations are logged and reviewed by the Security team.
+
+{% admonition(type="note") %}
+Access requests, approvals, and reviews must be retained as evidence for audit purposes. Store records in the approved GRC or ticketing system — email approvals alone are not sufficient.
+{% end %}

--- a/starter/content/policies/data-classification.md
+++ b/starter/content/policies/data-classification.md
@@ -1,0 +1,148 @@
+---
+title: "Data Classification Policy"
+description: "Framework for classifying, handling, and protecting organizational data"
+date: 2025-01-01
+weight: 30
+taxonomies:
+  SCF:
+    - DCH-01
+    - DCH-02
+    - DCH-03
+    - DCH-05
+    - DCH-06
+    - DCH-19
+  ISO27001:
+    - A.5.9
+    - A.5.10
+    - A.5.11
+    - A.5.12
+    - A.5.13
+    - A.8.10
+    - A.8.12
+extra:
+  owner: Security / Legal
+  last_reviewed: 2025-01-01
+  major_revisions:
+    - date: 2025-01-01
+      description: Initial policy.
+      revised_by: Security / Legal
+      approved_by: CEO
+      version: "1.0"
+---
+
+## Purpose and Scope
+
+This policy establishes a consistent framework for classifying {{ org() }}'s data assets and defines the handling requirements for each classification level. Proper classification ensures that sensitive information receives appropriate protection without creating unnecessary friction for non-sensitive data.
+
+This policy applies to all data created, collected, stored, processed, or transmitted by {{ org() }} or on its behalf, regardless of format or storage location.
+
+## Classification Levels
+
+{{ org() }} uses four data classification levels:
+
+### Public
+
+Information intended for or approved for public release.
+
+**Examples:** Marketing materials, published blog posts, public documentation, job listings
+
+**Handling:** No special controls required. May be shared freely.
+
+---
+
+### Internal
+
+Information for use within {{ org() }} that is not intended for external parties, but would cause minimal harm if inadvertently disclosed.
+
+**Examples:** Internal process documentation, meeting notes, non-sensitive project plans, general company communications
+
+**Handling:**
+- Do not share externally without business justification
+- Store on {{ org() }}-managed systems
+- No encryption required at rest (recommended for portability)
+
+---
+
+### Confidential
+
+Sensitive business information that could cause meaningful harm to {{ org() }} or its customers, partners, or employees if disclosed without authorization.
+
+**Examples:** Customer data, financial records, contracts, security configurations, HR records, source code
+
+**Handling:**
+- Access restricted to those with a business need
+- Encryption required at rest and in transit
+- Do not store on personal devices or unapproved cloud services
+- Must be explicitly marked as Confidential when shared
+
+---
+
+### Restricted
+
+The most sensitive information, where unauthorized disclosure could cause severe harm — legal, regulatory, financial, or reputational.
+
+**Examples:**
+
+{% redact() %}
+- Authentication credentials and cryptographic key material
+- Vulnerability details and penetration test reports
+- Acquisition or merger information prior to public disclosure
+- Regulated personal data (health records, payment card data, government IDs)
+{% end %}
+
+**Handling:**
+- Strict need-to-know access; access requests require CISO approval
+- Encryption required at rest (AES-256) and in transit (TLS 1.3+)
+- Must not be transmitted via email without additional encryption
+- Access logged and reviewed monthly
+- Disposal requires verified secure deletion or physical destruction
+
+## Classification Responsibilities
+
+| Role | Responsibility |
+|---|---|
+| Data owner | Assign initial classification at creation; review annually |
+| All staff | Handle data according to its classification; report mishandling |
+| Security team | Maintain classification guidance; review and audit compliance |
+| Legal / Compliance | Advise on regulatory obligations affecting classification |
+
+When in doubt, classify at the higher level and consult the Security team.
+
+## Handling Requirements Summary
+
+| Requirement | Public | Internal | Confidential | Restricted |
+|---|:---:|:---:|:---:|:---:|
+| Encryption at rest | | | ✓ | ✓ |
+| Encryption in transit | | | ✓ | ✓ |
+| Access controls | | ✓ | ✓ | ✓ |
+| Access logging | | | ✓ | ✓ |
+| Secure disposal | | | ✓ | ✓ |
+| CISO approval to share | | | | ✓ |
+
+## Data Retention and Disposal
+
+Data must be retained for the minimum period required by law or business need, then securely disposed of. Retention schedules are maintained by Legal.
+
+Secure disposal methods:
+
+- **Electronic data:** Cryptographic erasure or NIST 800-88-compliant wiping
+- **Physical media:** Cross-cut shredding (paper) or certified destruction (drives)
+- **Cloud data:** Verified deletion per provider's data destruction process
+
+{% admonition(type="note") %}
+Personal data subject to privacy regulations (GDPR, CCPA, etc.) has additional retention and disposal requirements. Consult Legal before deleting or retaining personal data beyond its primary use.
+{% end %}
+
+## Labelling
+
+Confidential and Restricted documents must be labelled:
+
+- Header or footer on printed documents
+- File name prefix or document properties for electronic files (e.g. `[CONFIDENTIAL]`)
+- Email subject line prefix when transmitting electronically
+
+## Compliance and Enforcement
+
+Mishandling of classified data — including storing Restricted data in unapproved locations, sharing Confidential data without authorization, or failure to apply required controls — may result in disciplinary action.
+
+Report suspected data mishandling to the Security team immediately.

--- a/starter/content/policies/incident-response.md
+++ b/starter/content/policies/incident-response.md
@@ -1,0 +1,155 @@
+---
+title: "Incident Response Policy"
+description: "Procedures for detecting, responding to, and recovering from security incidents"
+date: 2024-06-01
+weight: 20
+taxonomies:
+  SCF:
+    - IRO-01
+    - IRO-02
+    - IRO-04
+    - IRO-06
+    - IRO-07
+    - IRO-08
+    - IRO-10
+  ISO27001:
+    - A.5.24
+    - A.5.25
+    - A.5.26
+    - A.5.27
+    - A.5.28
+    - A.6.8
+extra:
+  owner: Security Team
+  last_reviewed: 2025-03-01
+  major_revisions:
+    - date: 2025-03-01
+      description: Added ransomware-specific playbook references and updated escalation contacts.
+      revised_by: Security Team
+      approved_by: CISO
+      version: "1.2"
+    - date: 2024-10-15
+      description: Revised severity matrix and SLA targets based on lessons learned from Q3 tabletop exercise.
+      revised_by: Security Team
+      approved_by: CISO
+      version: "1.1"
+    - date: 2024-06-01
+      description: Initial policy.
+      revised_by: Security Team
+      approved_by: CEO
+      version: "1.0"
+---
+
+## Purpose and Scope
+
+This policy defines {{ org() }}'s approach to managing security incidents — from initial detection through containment, eradication, recovery, and post-incident review. The goal is to minimize harm, preserve evidence, and prevent recurrence.
+
+This policy applies to all {{ org() }} employees, contractors, and systems.
+
+## Definitions
+
+- **Security Incident**: Any event that threatens the confidentiality, integrity, or availability of {{ org() }} information or systems, or violates security policy
+- **Security Event**: An observable occurrence that may indicate a potential incident (not all events are incidents)
+- **Critical Incident**: An incident that affects production systems, sensitive data, or regulatory obligations
+
+## Incident Severity
+
+| Severity | Description | Examples | Initial Response SLA |
+|---|---|---|---|
+| **P1 – Critical** | Significant business or data impact | Active ransomware, confirmed data breach, production system compromise | 15 minutes |
+| **P2 – High** | Potential significant impact if not contained | Suspected credential compromise, unauthorized access attempt on sensitive systems | 1 hour |
+| **P3 – Medium** | Limited impact, contained | Malware on isolated endpoint, policy violation | 4 hours |
+| **P4 – Low** | Minimal impact, informational | Failed phishing attempt with no compromise, suspicious email | 1 business day |
+
+## Incident Response Phases
+
+### 1. Detection and Reporting
+
+Anyone who suspects a security incident must report it immediately to the Security team via the designated incident channel. Do not attempt to investigate or remediate independently.
+
+Sources of detection include:
+
+- SIEM / monitoring alerts
+- Employee reports
+- Third-party notification (vendor, partner, law enforcement)
+- Vulnerability scanner findings
+- Threat intelligence feeds
+
+### 2. Triage and Severity Assignment
+
+The on-call Security team member triages the reported event within the SLA above, determines severity, and opens a formal incident ticket.
+
+### 3. Containment
+
+Containment strategy depends on severity:
+
+- **Short-term**: Isolate affected systems, revoke compromised credentials, block malicious IPs/domains
+- **Long-term**: Determine root cause before full restoration; preserve forensic evidence
+
+**Do not wipe or rebuild systems** until the Security team has approved evidence collection is complete.
+
+### 4. Eradication
+
+Remove the threat from the environment:
+
+- Identify and eliminate all attacker footholds
+- Patch or mitigate the exploited vulnerability
+- Reset all potentially compromised credentials
+
+### 5. Recovery
+
+Restore affected systems to normal operation:
+
+- Restore from known-good backups where possible
+- Validate system integrity before returning to production
+- Monitor restored systems closely for recurrence
+
+### 6. Post-Incident Review
+
+All P1 and P2 incidents require a post-incident review (PIR) within 5 business days of resolution. The PIR documents:
+
+- Timeline of events
+- What worked well
+- What needs improvement
+- Action items with owners and due dates
+
+PIR records are retained for a minimum of 3 years.
+
+## Escalation and Notification
+
+| Condition | Notify | Timeline |
+|---|---|---|
+| P1 incident | CISO, executive team | Immediately |
+| Suspected personal data breach | Legal, DPO | Within 24 hours of discovery |
+| Confirmed personal data breach | Regulator (if required) | Per applicable regulation |
+| Third-party systems involved | Affected vendor / partner | Within 48 hours |
+
+{% admonition(type="warning") %}
+If a breach may involve personal data subject to GDPR, CCPA, or other privacy regulation, notify Legal immediately. Regulatory notification deadlines (e.g. 72 hours under GDPR) begin from the point of discovery, not confirmation.
+{% end %}
+
+## Evidence Handling
+
+Evidence collected during an incident must be:
+
+- Documented (what, when, how collected, chain of custody)
+- Stored in a secure, access-controlled location
+- Retained for a minimum of 1 year (or longer if litigation is anticipated)
+
+Do not share evidence externally without Legal approval.
+
+## Roles and Responsibilities
+
+| Role | Responsibility |
+|---|---|
+| Security Team | Lead response, coordinate containment and eradication, own PIR |
+| IT / Engineering | Provide system access, execute technical remediation |
+| Legal / Compliance | Advise on notification obligations, external communications |
+| Communications | Manage internal and external messaging for significant incidents |
+| All staff | Report suspected incidents immediately; preserve evidence |
+
+## Related Documents
+
+- Incident Response Playbooks (internal wiki)
+- Business Continuity Plan
+- Data Breach Notification Procedure

--- a/templates/index.html
+++ b/templates/index.html
@@ -161,7 +161,7 @@ description=description, is_home=true) }}
 </section>
 {% endif %}
 
-{% set news_section = get_section(path="news/_index.md") %}
+{% set news_section = get_section(path="news/_index.md", required=false) %}
 {% if news_section and news_section.pages %}
 <section class="recent-updates-section">
   <div class="container">
@@ -236,7 +236,7 @@ description=description, is_home=true) }}
       {% endif %}
 
       <!-- Recent activity strip -->
-      {% set news_section = get_section(path="news/_index.md") %}
+      {% set news_section = get_section(path="news/_index.md", required=false) %}
       {% if news_section and news_section.pages %}
       <div class="activity-strip">
         <h2>Recent Updates</h2>


### PR DESCRIPTION
Adds a self-contained starter directory that users can copy into a new repo
to get up and running immediately. Includes:

- config.toml with all required fields commented and explained
- Three example policies: access control (SCF/ISO mapping), incident response
  (multi-revision history), data classification (redaction shortcode demo)
- .github/workflows/build.yml wired to sc2in/policypress@v1 that builds PDFs,
  deploys the Zola site to GitHub Pages, and exposes manual draft/redact runs
- README focused on the three-step quick start and action usage

Also fixes a template bug where index.html used get_section() without
required=false for the optional news section, causing Zola to error for
sites that do not have a news/ content directory.

Closes #62
