### PR TITLE
fix: draft.png resolution for theme layouts and ADO pipeline docs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -135,6 +135,15 @@ runs:
           cp -n themes/policypress/data/* data/
         fi
 
+    - name: Copy draft watermark
+      shell: bash
+      run: |
+        # The policypress binary looks for static/draft.png at the site root.
+        # Copy it from the theme so draft-mode builds work without the consumer
+        # having to vendor the asset. -n preserves any site-local override.
+        mkdir -p static
+        cp -n themes/policypress/static/draft.png static/ 2>/dev/null || true
+
     - name: Build site and PDFs
       id: build
       shell: nix develop "github:sc2in/policypress#ci" --command bash -e {0}

--- a/content/guides/installation.md
+++ b/content/guides/installation.md
@@ -109,6 +109,16 @@ trigger:
   branches:
     include:
       - main
+      - feature/*
+  paths:
+    include:
+      - content
+      - config.toml
+
+pr:
+  branches:
+    include:
+      - main
   paths:
     include:
       - content
@@ -118,9 +128,9 @@ variables:
   # Automatically publish production PDFs on main; all other branches get draft watermarks.
   - name: publish
     ${{ if eq(variables['Build.SourceBranchName'], 'main') }}:
-      value: true
+      value: 'true'
     ${{ else }}:
-      value: false
+      value: 'false'
 
 pool:
   vmImage: ubuntu-latest

--- a/content/guides/installation.md
+++ b/content/guides/installation.md
@@ -125,12 +125,9 @@ pr:
       - config.toml
 
 variables:
-  # Automatically publish production PDFs on main; all other branches get draft watermarks.
+  # Default to draft; overridden to 'true' at runtime on main (see step below).
   - name: publish
-    ${{ if eq(variables['Build.SourceBranchName'], 'main') }}:
-      value: 'true'
-    ${{ else }}:
-      value: 'false'
+    value: 'false'
 
 pool:
   vmImage: ubuntu-latest
@@ -138,6 +135,11 @@ pool:
 steps:
   - checkout: self
     submodules: true
+
+  # Automatically publish production PDFs on main; all other branches get draft watermarks.
+  - bash: echo "##vso[task.setvariable variable=publish]true"
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+    displayName: Enable publish on main
 
   - bash: |
       set -euo pipefail

--- a/content/guides/installation.md
+++ b/content/guides/installation.md
@@ -109,51 +109,70 @@ trigger:
   branches:
     include:
       - main
+  paths:
+    include:
+      - content
+      - config.toml
+
+variables:
+  # Automatically publish production PDFs on main; all other branches get draft watermarks.
+  - name: publish
+    ${{ if eq(variables['Build.SourceBranchName'], 'main') }}:
+      value: true
+    ${{ else }}:
+      value: false
 
 pool:
   vmImage: ubuntu-latest
 
-parameters:
-  - name: draft_mode
-    type: boolean
-    default: false
-  - name: redact_mode
-    type: boolean
-    default: false
-
 steps:
   - checkout: self
+    submodules: true
 
   - bash: |
       set -euo pipefail
-      # Install Nix — required for Pandoc, mermaid-filter, and Chromium
-      curl --proto '=https' --tlsv1.2 -sSfL https://install.determinate.systems/nix \
-        | sh -s -- install linux --no-confirm
-      echo '/nix/var/nix/profiles/default/bin' >> "$BASH_ENV"
+      # Ubuntu 22.04+ requires this before Nix can create user namespaces.
+      sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+      curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
+        | sh -s -- install linux --no-confirm \
+            --extra-conf "sandbox = false" \
+            --extra-conf "trusted-users = root vsts"
+      . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+      nix --version
     displayName: Install Nix
 
   - bash: |
       set -euo pipefail
-      FLAGS=()
-      [[ "${{ parameters.draft_mode }}" == "True" ]] && FLAGS+=(--draft)
-      [[ "${{ parameters.redact_mode }}" == "True" ]] && FLAGS+=(--redact)
-      nix develop github:sc2in/policypress --command bash -c "
-        zola build
-        policypress ${FLAGS[*]:-} -c config.toml -o public
-      "
+      . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+      nix develop github:sc2in/policypress#ci --command zola build
+      if [ "$(publish)" = "true" ]; then
+        nix run github:sc2in/policypress -- -c config.toml -o public/pdfs
+        nix run github:sc2in/policypress -- -c config.toml -o public/pdfs --redact
+      else
+        nix run github:sc2in/policypress -- -c config.toml -o public/pdfs --draft
+        nix run github:sc2in/policypress -- -c config.toml -o public/pdfs --draft --redact
+      fi
     displayName: Build site and PDFs
 
-  - publish: $(Build.SourcesDirectory)/public/pdfs
-    artifact: pdfs
-
   - publish: $(Build.SourcesDirectory)/public
-    artifact: site
+    artifact: WebApp
 ```
 
-Link it to a pipeline in **Azure DevOps → Pipelines → New pipeline**, point it at this file, and set it to trigger on changes to `main`.
+Link it to a pipeline in **Azure DevOps → Pipelines → New pipeline** and point it at this file.
+
+To deploy to Azure Static Web Apps, add this step after the publish task and store the deployment token as a pipeline variable named `deployment_token`:
+
+```yaml
+  - task: AzureStaticWebApp@0
+    condition: and(succeeded(), eq(variables.publish, 'true'))
+    inputs:
+      app_location: public
+      skip_app_build: true
+      azure_static_web_apps_api_token: $(deployment_token)
+```
 
 > [!NOTE]
-> The first run downloads the Nix environment (~1–2 GB). Subsequent runs are faster if you configure a Nix binary cache. See the [Determinate Systems docs](https://docs.determinate.systems/flakehub-cache/) for caching options compatible with ADO agents.
+> The first run downloads the Nix environment (~1–2 GB) and compiles the policypress binary, which takes 15–20 minutes. Subsequent runs are faster with a Nix binary cache — see [Determinate Systems FlakeHub Cache](https://docs.determinate.systems/flakehub-cache/) for ADO-compatible options. For the fastest cold starts, replace `nix run github:sc2in/policypress` with a pre-compiled binary downloaded from the [latest release](https://github.com/sc2in/policypress/releases/latest).
 
 </div>
 </div>

--- a/src/pandoc.zig
+++ b/src/pandoc.zig
@@ -1,11 +1,11 @@
 //! Copyright © 2025 [Star City Security Consulting, LLC (SC2)](https://sc2.in)
 //! SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 const std = @import("std");
-const builtin = @import("builtin");
 const Array = std.ArrayList;
 const Allocator = std.mem.Allocator;
 const tst = std.testing;
 const math = std.math;
+const builtin = @import("builtin");
 
 const clap = @import("clap");
 const Config = @import("config").Config;
@@ -195,18 +195,12 @@ pub fn create_global_args(a: Allocator, args: *Array([]u8), config: Config) !voi
     try add_arg(a, args, "", "--pdf-engine=xelatex", .{});
 
     if (config.is_draft) {
-        const draft_path = blk: {
+        const draft_path: ?[]const u8 = blk: {
             const primary = try std.fs.path.join(a, &.{ config.root, "static", "draft.png" });
-            std.fs.accessAbsolute(primary, .{}) catch |err| switch (err) {
-                error.FileNotFound => {
-                    a.free(primary);
-                },
-                else => return err,
-            };
             if (std.fs.accessAbsolute(primary, .{})) |_| {
                 break :blk primary;
             } else |err| switch (err) {
-                error.FileNotFound => unreachable,
+                error.FileNotFound => a.free(primary),
                 else => return err,
             }
 

--- a/src/pandoc.zig
+++ b/src/pandoc.zig
@@ -195,7 +195,23 @@ pub fn create_global_args(a: Allocator, args: *Array([]u8), config: Config) !voi
     try add_arg(a, args, "", "--pdf-engine=xelatex", .{});
 
     if (config.is_draft) {
-        try add_arg(a, args, "-V", "page-background=static/draft.png", .{});
+        const draft_path = blk: {
+            const primary = try std.fs.path.join(a, &.{ config.root, "static", "draft.png" });
+            if (std.fs.accessAbsolute(primary, .{})) |_| {
+                break :blk primary;
+            } else |_| {
+                a.free(primary);
+            }
+            // When policypress is used as a Zola theme (submodule), the watermark
+            // lives under themes/policypress/static/ rather than at the site root.
+            const fallback = try std.fs.path.join(a, &.{ config.root, "themes", "policypress", "static", "draft.png" });
+            if (std.fs.accessAbsolute(fallback, .{})) |_| {} else |_| {
+                std.log.warn("draft.png not found at site root or in themes/policypress/static/; draft watermark will be missing", .{});
+            }
+            break :blk fallback;
+        };
+        defer a.free(draft_path);
+        try add_arg(a, args, "-V", "page-background={s}", .{draft_path});
         try add_arg(a, args, "-V", "page-background-opacity=0.8", .{});
     }
 }

--- a/src/pandoc.zig
+++ b/src/pandoc.zig
@@ -197,22 +197,38 @@ pub fn create_global_args(a: Allocator, args: *Array([]u8), config: Config) !voi
     if (config.is_draft) {
         const draft_path = blk: {
             const primary = try std.fs.path.join(a, &.{ config.root, "static", "draft.png" });
+            std.fs.accessAbsolute(primary, .{}) catch |err| switch (err) {
+                error.FileNotFound => {
+                    a.free(primary);
+                },
+                else => return err,
+            };
             if (std.fs.accessAbsolute(primary, .{})) |_| {
                 break :blk primary;
-            } else |_| {
-                a.free(primary);
+            } else |err| switch (err) {
+                error.FileNotFound => unreachable,
+                else => return err,
             }
+
             // When policypress is used as a Zola theme (submodule), the watermark
             // lives under themes/policypress/static/ rather than at the site root.
             const fallback = try std.fs.path.join(a, &.{ config.root, "themes", "policypress", "static", "draft.png" });
-            if (std.fs.accessAbsolute(fallback, .{})) |_| {} else |_| {
-                std.log.warn("draft.png not found at site root or in themes/policypress/static/; draft watermark will be missing", .{});
+            if (std.fs.accessAbsolute(fallback, .{})) |_| {
+                break :blk fallback;
+            } else |err| switch (err) {
+                error.FileNotFound => {
+                    a.free(fallback);
+                    std.log.warn("draft.png not found at site root or in themes/policypress/static/; draft watermark will be skipped", .{});
+                    break :blk null;
+                },
+                else => return err,
             }
-            break :blk fallback;
         };
-        defer a.free(draft_path);
-        try add_arg(a, args, "-V", "page-background={s}", .{draft_path});
-        try add_arg(a, args, "-V", "page-background-opacity=0.8", .{});
+        if (draft_path) |path| {
+            defer a.free(path);
+            try add_arg(a, args, "-V", "page-background={s}", .{path});
+            try add_arg(a, args, "-V", "page-background-opacity=0.8", .{});
+        }
     }
 }
 

--- a/src/test.zig
+++ b/src/test.zig
@@ -542,8 +542,8 @@ test "draft mode: uses site-root static/draft.png when present" {
 
     const path = findPageBackground(args) orelse return error.NoBgArg;
     // Must point at the site-root copy, not the theme fallback.
-    try tst.expect(std.mem.indexOf(u8, path, "static/draft.png") != null);
-    try tst.expect(std.mem.indexOf(u8, path, "themes/policypress") == null);
+    try tst.expect(std.mem.indexOf(u8, path, "static" ++ std.fs.path.sep_str ++ "draft.png") != null);
+    try tst.expect(std.mem.indexOf(u8, path, "themes" ++ std.fs.path.sep_str ++ "policypress") == null);
 }
 
 test "draft mode: falls back to themes/policypress/static/draft.png when site-root copy absent" {
@@ -566,7 +566,7 @@ test "draft mode: falls back to themes/policypress/static/draft.png when site-ro
     defer pandoc.destroy_global_args(alloc, &args);
 
     const path = findPageBackground(args) orelse return error.NoBgArg;
-    try tst.expect(std.mem.indexOf(u8, path, "themes/policypress/static/draft.png") != null);
+    try tst.expect(std.mem.indexOf(u8, path, "themes" ++ std.fs.path.sep_str ++ "policypress" ++ std.fs.path.sep_str ++ "static" ++ std.fs.path.sep_str ++ "draft.png") != null);
 }
 
 test "draft mode: site-root static/draft.png wins over theme fallback when both exist" {
@@ -591,7 +591,7 @@ test "draft mode: site-root static/draft.png wins over theme fallback when both 
     defer pandoc.destroy_global_args(alloc, &args);
 
     const path = findPageBackground(args) orelse return error.NoBgArg;
-    try tst.expect(std.mem.indexOf(u8, path, "themes/policypress") == null);
+    try tst.expect(std.mem.indexOf(u8, path, "themes" ++ std.fs.path.sep_str ++ "policypress") == null);
 }
 
 // --- executableInPath ---

--- a/src/test.zig
+++ b/src/test.zig
@@ -509,3 +509,98 @@ test "redact mode: title suffix and content scrubbed" {
     // Redacted blocks become underscores, not visible text.
     try tst.expect(std.mem.indexOf(u8, contents.items, &[_]u8{'_'} ** 10) != null);
 }
+
+// --- draft.png path resolution ---
+
+// Helper: find the page-background= value among pandoc args.
+fn findPageBackground(args: Array([]u8)) ?[]const u8 {
+    for (args.items) |arg| {
+        if (std.mem.startsWith(u8, arg, "page-background="))
+            return arg["page-background=".len..];
+    }
+    return null;
+}
+
+test "draft mode: uses site-root static/draft.png when present" {
+    const alloc = tst.allocator;
+    var args = Array([]u8){};
+    var conf = try config.load(alloc, TestConfig);
+    defer conf.deinit(alloc);
+
+    var tmp = tst.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(tmp_path);
+    try tmp.dir.makePath("static");
+    try tmp.dir.writeFile(.{ .sub_path = "static/draft.png", .data = "" });
+
+    alloc.free(conf.root);
+    conf.root = try alloc.dupe(u8, tmp_path);
+    conf.is_draft = true;
+    try pandoc.create_global_args(alloc, &args, conf);
+    defer pandoc.destroy_global_args(alloc, &args);
+
+    const path = findPageBackground(args) orelse return error.NoBgArg;
+    // Must point at the site-root copy, not the theme fallback.
+    try tst.expect(std.mem.indexOf(u8, path, "static/draft.png") != null);
+    try tst.expect(std.mem.indexOf(u8, path, "themes/policypress") == null);
+}
+
+test "draft mode: falls back to themes/policypress/static/draft.png when site-root copy absent" {
+    const alloc = tst.allocator;
+    var args = Array([]u8){};
+    var conf = try config.load(alloc, TestConfig);
+    defer conf.deinit(alloc);
+
+    var tmp = tst.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(tmp_path);
+    try tmp.dir.makePath("themes/policypress/static");
+    try tmp.dir.writeFile(.{ .sub_path = "themes/policypress/static/draft.png", .data = "" });
+
+    alloc.free(conf.root);
+    conf.root = try alloc.dupe(u8, tmp_path);
+    conf.is_draft = true;
+    try pandoc.create_global_args(alloc, &args, conf);
+    defer pandoc.destroy_global_args(alloc, &args);
+
+    const path = findPageBackground(args) orelse return error.NoBgArg;
+    try tst.expect(std.mem.indexOf(u8, path, "themes/policypress/static/draft.png") != null);
+}
+
+test "draft mode: site-root static/draft.png wins over theme fallback when both exist" {
+    const alloc = tst.allocator;
+    var args = Array([]u8){};
+    var conf = try config.load(alloc, TestConfig);
+    defer conf.deinit(alloc);
+
+    var tmp = tst.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(tmp_path);
+    try tmp.dir.makePath("static");
+    try tmp.dir.writeFile(.{ .sub_path = "static/draft.png", .data = "" });
+    try tmp.dir.makePath("themes/policypress/static");
+    try tmp.dir.writeFile(.{ .sub_path = "themes/policypress/static/draft.png", .data = "" });
+
+    alloc.free(conf.root);
+    conf.root = try alloc.dupe(u8, tmp_path);
+    conf.is_draft = true;
+    try pandoc.create_global_args(alloc, &args, conf);
+    defer pandoc.destroy_global_args(alloc, &args);
+
+    const path = findPageBackground(args) orelse return error.NoBgArg;
+    try tst.expect(std.mem.indexOf(u8, path, "themes/policypress") == null);
+}
+
+// --- executableInPath ---
+
+test "executableInPath: sh is present on unix" {
+    if (comptime b.os.tag == .windows) return error.SkipZigTest;
+    try tst.expect(pandoc.executableInPath("sh"));
+}
+
+test "executableInPath: nonexistent binary returns false" {
+    try tst.expect(!pandoc.executableInPath("pp-test-nonexistent-xyzzy-12345"));
+}


### PR DESCRIPTION
## Summary

- **Fix `draft.png` not found when used as a Zola theme (#103)** — the binary now resolves the watermark by checking `static/draft.png` at the site root first, then falling back to `themes/policypress/static/draft.png` for submodule/theme layouts. The GitHub Action also now copies `draft.png` from the theme alongside the existing template/shortcode/data copy steps.

- **Fix Azure DevOps pipeline example (#105)** — the ADO tab in the installation guide was missing the AppArmor `sysctl` flag, `sandbox = false` and `trusted-users = root vsts` nix install flags, the `#ci` devshell, proper nix daemon profile sourcing, `submodules: true`, and a branch-conditional `publish` variable that automatically produces draft PDFs on feature branches and production PDFs on `main`. The deploy step is now shown as an explicit optional add-on.

- **Tests for `draft.png` fallback and `executableInPath`** — five new tests covering the primary path, theme fallback, tie-breaking between both, and both branches of `executableInPath`.

## Test plan

- [x] `zig build test` passes (all 27 tests green, including 5 new ones)
- [ ] Draft-mode PDF build with policypress as a git submodule produces watermarked PDFs
- [ ] Draft-mode PDF build with `static/draft.png` present at site root still works
- [ ] Azure DevOps pipeline following the updated guide installs Nix cleanly on Ubuntu 22.04+

## Closes

- #103
- #105