### PR TITLE
fix: harden redaction and PDF-generation correctness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,16 @@ jobs:
             om ci run
           fi
 
+      # End-to-end guard for the redaction feature: build the demo site and
+      # redacted PDFs and assert no {% redact() %} content survives into the
+      # published site (HTML, search index, feeds) or the PDF output dir.
+      - name: Redaction leak check
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        shell: nix develop --command bash -e {0}
+        run: |
+          zig build
+          bash tests/redaction-leak-check.sh
+
       - name: Collect artifacts
         if: ${{ success() && matrix.os == 'ubuntu-latest' && (github.ref_type == 'tag' || github.ref_name == 'main') }}
         run: |
@@ -132,6 +142,10 @@ jobs:
               [[ "$target" == *windows* ]] && ext=".exe"
               cp "zig-out/bin/policypress${ext}" "policypress-${target}${ext}"
             done
+            # Publish checksums so the composite action can verify the binary it
+            # downloads matches the one built here for this exact tag.
+            sha256sum policypress-* > SHA256SUMS.txt
+            cat SHA256SUMS.txt
           '
 
       - name: Create GitHub Release
@@ -140,6 +154,7 @@ jobs:
         with:
           files: |
             policypress-*
+            SHA256SUMS.txt
           generate_release_notes: true
 
       - name: Update floating major version tag

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.pdf
 static/pdfs/
 *.tmp.html
+.pp_*.typ
 **/internal/*
 **/node_modules/*
 **/public/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,56 @@ keys) is considered stable.
 
 ## [Unreleased]
 
+### Security
+
+- **Web redaction now renders visible bars server-side.** Building on 1.4.1
+  (which stopped emitting the body), the `{% redact() %}` shortcode now emits
+  solid `█` bars sized to the hidden content when `redact_web = true`, so a
+  redacted policy shows a clear redaction mark while the text still never
+  reaches the HTML, the client-side search index, or the RSS/Atom feed.
+- **Composite action pins and verifies the binary.** The action downloads the
+  release binary for the exact pinned action ref (e.g. `@v1.4.1`) instead of the
+  latest release, verifies it against a published `SHA256SUMS.txt`, and falls
+  back to building from source for refs without a release. `ci` now publishes
+  the checksums alongside the release binaries.
+- **Action inputs are no longer spliced into the build script.** Inputs such as
+  `base_url` are passed through the environment instead of `${{ }}`
+  interpolation, removing a shell-injection surface on the consumer's runner.
+
+### Fixed
+
+- **Redacted PDFs no longer corrupt legitimate underscores.** Redaction masked
+  spans with underscores and then converted *every* `_` in the body to `█`,
+  mangling snake_case identifiers, `_emphasis_`, and URLs in the redacted PDF.
+  Redacted spans are now masked with `█` directly and only the spans change.
+- **Whitespace-trim redaction tags are honored.** `{%- redact() -%}` /
+  `{%- end -%}` variants are now redacted (and still caught when orphaned)
+  rather than passing through unmasked.
+- **Policy version is chosen by date, not string order.** Selection now matches
+  the website (most recent by `date`, numeric version tiebreak), so `1.10` no
+  longer loses to `1.9` and the PDF and site never disagree on the version.
+- **Incremental-build stamps are keyed by full path.** Two policies with the
+  same file name in different directories no longer share a stamp, which could
+  cause the second to be skipped as "up to date" with no PDF produced.
+- **Colliding PDF names fail the build.** Two policies that resolve to the same
+  `{Title}_-_v{version}.pdf` now stop the build (naming both files) instead of
+  silently overwriting one another.
+- **Site PDF links match the generated files.** The download links on policy
+  pages and the PDF filenames now share one sanitizer, so a title with
+  punctuation no longer produces a 404 link.
+- **`draft: true` policies are excluded from PDF generation**, matching Zola
+  (which omits drafts from the site) and the documentation, so an unapproved
+  draft no longer gets an official-looking PDF at a guessable URL.
+- **Mobile navigation works again.** The menu button is a real toggle wired to
+  the collapse handler, so the nav and search are reachable below the `md`
+  breakpoint.
+
+### Added
+
+- `tests/redaction-leak-check.sh` builds the demo site and redacted PDFs and
+  asserts no `{% redact() %}` content survives into the site (HTML, search
+  index, feeds) or the PDF output directory. It runs in CI on Linux.
+
 ## [1.4.1] - 2026-07-04
 
 ### Security (GHSA-j557-r6p7-8r3m)

--- a/action.yml
+++ b/action.yml
@@ -89,14 +89,20 @@ runs:
       run: |
         mkdir -p "${RUNNER_TEMP}/policypress-bin"
 
-        if [ -z "${{ steps.get-ref.outputs.ref }}" ]; then
-          # Running via `uses: ./` from a checkout of this repo (e.g. the PR
-          # preview workflow). Build the binary from the action's own flake so
-          # previews exercise the code under review — the latest release binary
-          # may not even match this branch's toolchain.
-          echo "No action ref (local action) - building policypress from the flake…"
+        build_from_flake() {
+          # Build the binary from the action's own checkout (pinned at the ref
+          # the consumer selected), so the binary always matches the theme code
+          # under `uses:`. Used for local `uses: ./` runs and whenever no
+          # release asset exists for the pinned ref (e.g. a branch or major-tag
+          # pin like @v1 that has no per-ref release).
+          echo "Building policypress from the flake at the pinned ref…"
           out="$(nix build "path:${{ github.action_path }}#policypress-safe" --print-out-paths --no-link)"
           install -m755 "${out}/bin/policypress" "${RUNNER_TEMP}/policypress-bin/policypress"
+        }
+
+        REF="${{ steps.get-ref.outputs.ref }}"
+        if [ -z "${REF}" ]; then
+          build_from_flake
         else
           case "$(uname -s)-$(uname -m)" in
             Linux-x86_64)   BINARY="policypress-x86_64-linux" ;;
@@ -109,13 +115,24 @@ runs:
               ;;
           esac
 
-          gh release download \
-            --repo sc2in/policypress \
-            --pattern "${BINARY}" \
-            --dir "${RUNNER_TEMP}/policypress-bin"
-          mv "${RUNNER_TEMP}/policypress-bin/${BINARY}" \
-             "${RUNNER_TEMP}/policypress-bin/policypress"
-          chmod +x "${RUNNER_TEMP}/policypress-bin/policypress"
+          # Download the release binary for the EXACT pinned ref (not "latest"),
+          # so pinning `uses: sc2in/policypress@vX.Y.Z` runs the vX.Y.Z binary.
+          bindir="${RUNNER_TEMP}/policypress-bin"
+          if gh release download "${REF}" --repo sc2in/policypress \
+               --pattern "${BINARY}" --dir "${bindir}"; then
+            # Verify the download against the release checksums when present.
+            if gh release download "${REF}" --repo sc2in/policypress \
+                 --pattern "SHA256SUMS.txt" --dir "${bindir}" 2>/dev/null; then
+              ( cd "${bindir}" && grep " ${BINARY}\$" SHA256SUMS.txt | sha256sum -c - )
+            else
+              echo "::warning::No SHA256SUMS.txt on release ${REF}; skipping checksum verification."
+            fi
+            mv "${bindir}/${BINARY}" "${bindir}/policypress"
+            chmod +x "${bindir}/policypress"
+          else
+            echo "::warning::No release asset ${BINARY} for ref ${REF}; building from source."
+            build_from_flake
+          fi
         fi
 
         echo "${RUNNER_TEMP}/policypress-bin" >> "${GITHUB_PATH}"
@@ -155,25 +172,36 @@ runs:
       # (typst, zola, fonts) always matches the action version in use instead
       # of floating on main. Also works for in-repo `uses: ./` workflows.
       shell: nix develop "path:${{ github.action_path }}#ci" --command bash -e {0}
+      # Inputs are passed through the environment, never interpolated into the
+      # script body: a value like base_url can come from an untrusted source
+      # (e.g. a PR preview URL) and `${{ }}` splicing would allow shell
+      # injection on the consumer's runner.
+      env:
+        PP_CONFIG_PATH: ${{ inputs.config_path }}
+        PP_OUTPUT_DIR: ${{ inputs.output_dir }}
+        PP_BASE_URL: ${{ inputs.base_url }}
+        PP_DRAFT_MODE: ${{ inputs.draft_mode }}
+        PP_REDACT_MODE: ${{ inputs.redact_mode }}
+        PP_GENERATE_DRAFT_PDFS: ${{ inputs.generate_draft_pdfs }}
       run: |
         set -euo pipefail
 
         # Build the Zola static site
         ZOLA_ARGS=()
-        if [ -n "${{ inputs.base_url }}" ]; then
-          ZOLA_ARGS+=(--base-url "${{ inputs.base_url }}")
+        if [ -n "${PP_BASE_URL}" ]; then
+          ZOLA_ARGS+=(--base-url "${PP_BASE_URL}")
         fi
         zola build "${ZOLA_ARGS[@]}"
 
         # Build flags - explicitly set draft/redact so action inputs always
         # override whatever is in the consumer's config.toml.
-        ARGS=(-c "${{ inputs.config_path }}" -o "${{ inputs.output_dir }}/pdfs")
-        if [ "${{ inputs.draft_mode }}" = "true" ]; then
+        ARGS=(-c "${PP_CONFIG_PATH}" -o "${PP_OUTPUT_DIR}/pdfs")
+        if [ "${PP_DRAFT_MODE}" = "true" ]; then
           ARGS+=(--draft)
         else
           ARGS+=(--no-draft)
         fi
-        if [ "${{ inputs.redact_mode }}" = "true" ]; then
+        if [ "${PP_REDACT_MODE}" = "true" ]; then
           ARGS+=(--redact)
         else
           ARGS+=(--no-redact)
@@ -184,9 +212,9 @@ runs:
 
         # Optionally generate a second draft-watermarked set of PDFs so that
         # sites with show_draft_pdfs = true have valid files to link to.
-        if [ "${{ inputs.generate_draft_pdfs }}" = "true" ]; then
-          DRAFT_ARGS=(-c "${{ inputs.config_path }}" -o "${{ inputs.output_dir }}/pdfs" --draft)
-          if [ "${{ inputs.redact_mode }}" = "true" ]; then
+        if [ "${PP_GENERATE_DRAFT_PDFS}" = "true" ]; then
+          DRAFT_ARGS=(-c "${PP_CONFIG_PATH}" -o "${PP_OUTPUT_DIR}/pdfs" --draft)
+          if [ "${PP_REDACT_MODE}" = "true" ]; then
             DRAFT_ARGS+=(--redact)
           else
             DRAFT_ARGS+=(--no-redact)
@@ -194,6 +222,6 @@ runs:
           policypress "${DRAFT_ARGS[@]}"
         fi
 
-        echo "pdf_path=${{ inputs.output_dir }}/pdfs"    >> "$GITHUB_OUTPUT"
-        echo "site_path=public"                          >> "$GITHUB_OUTPUT"
-        echo "report_path=${{ inputs.output_dir }}/reports" >> "$GITHUB_OUTPUT"
+        echo "pdf_path=${PP_OUTPUT_DIR}/pdfs"    >> "$GITHUB_OUTPUT"
+        echo "site_path=public"                  >> "$GITHUB_OUTPUT"
+        echo "report_path=${PP_OUTPUT_DIR}/reports" >> "$GITHUB_OUTPUT"

--- a/sass/common/_global.scss
+++ b/sass/common/_global.scss
@@ -248,13 +248,15 @@ article {
   }
 }
 
-// Redaction blocks - body text is hidden behind a solid black bar.
-// white-space: pre-wrap preserves line breaks for multi-line redactions.
+// Redaction blocks - the content is replaced server-side with solid █ bars
+// (the text never reaches the page), then tinted so the glyphs read as one
+// continuous bar. overflow-wrap lets a long bar break instead of overflowing.
 .redaction {
   display: inline;
   background-color: $black;
   color: transparent;
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
   border-radius: 2px;
   user-select: none;
   cursor: default;

--- a/src/main.zig
+++ b/src/main.zig
@@ -21,6 +21,7 @@ const Config = @import("config").Config;
 const Date = @import("utils").Date;
 const Reports = @import("reports");
 const stampIsNewer = @import("utils").stampIsNewer;
+const isDraftPolicy = @import("utils").isDraftPolicy;
 const Typst = @import("typst");
 const writeStamp = @import("utils").writeStamp;
 
@@ -165,6 +166,7 @@ fn handleBuildError(err: anyerror) void {
         error.PolicyDirUnreadable,
         error.OutputDirFailed,
         error.CompilationFailed,
+        error.DuplicateOutputName,
         => {},
         // Anything unexpected.
         else => std.debug.print(
@@ -344,6 +346,7 @@ fn runBuild(io: std.Io, env: *EnvMap, alloc: Allocator, args: []const [:0]const 
         file_paths.deinit(alloc);
     }
     var skipped: usize = 0;
+    var drafts_skipped: usize = 0;
     while (walker.next(io) catch |err| {
         std.debug.print(
             "policypress: error while scanning policy directory: {s}\n",
@@ -358,6 +361,14 @@ fn runBuild(io: std.Io, env: *EnvMap, alloc: Allocator, args: []const [:0]const 
             if (stampIsNewer(io, input_path, stamps_dir_path, alloc)) {
                 alloc.free(input_path);
                 skipped += 1;
+                continue;
+            }
+            // Skip `draft: true` policies: Zola omits them from the site, so a
+            // draft must not get an official-looking PDF at a guessable URL.
+            if (isDraftPolicy(io, alloc, policy_dir, entry.path)) {
+                std.log.info("policypress: skipping draft policy '{s}'", .{entry.path});
+                alloc.free(input_path);
+                drafts_skipped += 1;
                 continue;
             }
             try file_paths.append(alloc, input_path);
@@ -375,6 +386,39 @@ fn runBuild(io: std.Io, env: *EnvMap, alloc: Allocator, args: []const [:0]const 
     }
     if (skipped > 0) {
         std.log.info("policypress: {d} up to date, rebuilding {d}.", .{ skipped, total_files });
+    }
+
+    // --- Detect output-filename collisions ---
+    // Two policies with the same title + version resolve to the same PDF name
+    // and would race to the same path during concurrent compilation, silently
+    // overwriting one another (exit 0, one PDF missing). Fail loudly instead,
+    // naming both offending files so the author can disambiguate.
+    {
+        var seen = std.StringHashMap([]const u8).init(alloc);
+        defer {
+            var it = seen.keyIterator();
+            while (it.next()) |k| alloc.free(k.*);
+            seen.deinit();
+        }
+        for (file_paths.items) |input_path| {
+            const name = Typst.outputName(io, alloc, config, input_path) catch |err| {
+                // A metadata error here (e.g. missing title) will resurface as
+                // a proper per-file compile error below; don't fail the whole
+                // build during the collision pre-pass.
+                std.log.debug("policypress: could not pre-compute output name for '{s}': {s}", .{ input_path, @errorName(err) });
+                continue;
+            };
+            if (seen.get(name)) |other| {
+                std.debug.print(
+                    "policypress: two policies produce the same PDF '{s}':\n  {s}\n  {s}\n" ++
+                        "Give them distinct titles or versions.\n",
+                    .{ name, other, input_path },
+                );
+                alloc.free(name);
+                return error.DuplicateOutputName;
+            }
+            try seen.put(name, input_path);
+        }
     }
 
     // --- Parallel compilation ---

--- a/src/test.zig
+++ b/src/test.zig
@@ -110,7 +110,9 @@ test "policy processing" {
     try tst.expectEqualStrings("2025-02-24", f1.last_reviewed);
     const out_file_name = try f1.filename(tst.allocator);
     defer tst.allocator.free(out_file_name);
-    try tst.expectEqualStrings("Test_Policy_(Redacted)_-_v1.1.pdf", out_file_name);
+    // filename() applies the canonical sanitiser, so "(Redacted)" becomes
+    // "__Redacted__" — the actual name on disk, matching the site's links.
+    try tst.expectEqualStrings("Test_Policy__Redacted__-_v1.1.pdf", out_file_name);
 
     try utils.replace_zola_at(tst.allocator, &t1, "https://test.lol");
     try utils.replace_org(tst.allocator, &t1, "loltest");
@@ -118,7 +120,8 @@ test "policy processing" {
     try utils.redact(tst.allocator, &t1, true);
 
     try tst.expect(std.mem.indexOf(u8, t1.items, "~~~mermaid") != null);
-    try tst.expect(std.mem.indexOf(u8, t1.items, &[_]u8{'_'} ** 10) != null);
+    // Redacted spans are masked with solid █ bars, not underscore placeholders.
+    try tst.expect(std.mem.indexOf(u8, t1.items, "██████████") != null);
     try tst.expectEqual(3, std.mem.count(u8, t1.items, "https://test.lol/"));
     try tst.expectEqual(0, std.mem.count(u8, t1.items, "{% end %}"));
 }
@@ -196,6 +199,11 @@ test "typst source: redaction produces solid bars" {
     // Redacted spans must render as solid █ bars, not underscores (which
     // CommonMark would turn into thematic breaks).
     try tst.expect(std.mem.indexOf(u8, rendered.source, "█") != null);
+    // Golden no-leak: the redact block's content must NOT survive anywhere in
+    // the Typst source that becomes the redacted PDF.
+    try tst.expect(std.mem.indexOf(u8, rendered.source, "sensitive information that should not be disclosed") == null);
+    // No unconsumed redaction tag may remain either.
+    try tst.expect(std.mem.indexOf(u8, rendered.source, "{% redact") == null);
     // Sanitised filename carries the __Redacted__ pattern that the Zola
     // templates hardcode in PDF links (issue #97).
     try tst.expectEqualStrings("Test_Policy__Redacted__-_v1.1.pdf", rendered.pdf_name);
@@ -253,8 +261,12 @@ test "stamp: writeStamp → stampIsNewer returns true" {
 
     utils.writeStamp(io, alloc, tmp_path, src_path);
 
-    // Set stamp mtime to 2 s in the future so it is definitely newer.
-    const stamp_path = try std.fs.path.join(alloc, &.{ tmp_path, "policy" });
+    // Set stamp mtime to 2 s in the future so it is definitely newer. The
+    // stamp filename is keyed by the full path (separators flattened), not the
+    // bare stem, so two same-named policies in different dirs never collide.
+    const stamp_name = try utils.stampName(alloc, src_path);
+    defer alloc.free(stamp_name);
+    const stamp_path = try std.fs.path.join(alloc, &.{ tmp_path, stamp_name });
     defer alloc.free(stamp_path);
     const stamp_file = try std.Io.Dir.cwd().openFile(io, stamp_path, .{ .mode = .read_write });
     defer stamp_file.close(io);
@@ -268,7 +280,7 @@ test "stamp: writeStamp → stampIsNewer returns true" {
     try tst.expect(utils.stampIsNewer(io, src_path, tmp_path, alloc));
 }
 
-test "stamp: writeStamp creates file with correct stem" {
+test "stamp: writeStamp creates a stamp file keyed by full path" {
     const alloc = tst.allocator;
     var tmp = tst.tmpDir(.{});
     defer tmp.cleanup();
@@ -282,9 +294,44 @@ test "stamp: writeStamp creates file with correct stem" {
     try tst.expect(!utils.stampIsNewer(io, src_path, tmp_path, alloc));
     utils.writeStamp(io, alloc, tmp_path, src_path);
 
-    const stem_path = try std.fs.path.join(alloc, &.{ tmp_path, "access-control" });
-    defer alloc.free(stem_path);
-    try std.Io.Dir.accessAbsolute(io, stem_path, .{});
+    const stamp_name = try utils.stampName(alloc, src_path);
+    defer alloc.free(stamp_name);
+    const stamp_path = try std.fs.path.join(alloc, &.{ tmp_path, stamp_name });
+    defer alloc.free(stamp_path);
+    try std.Io.Dir.accessAbsolute(io, stamp_path, .{});
+}
+
+test "stamp: same filename in different dirs gets distinct stamps" {
+    // Regression: keying stamps by basename made two policies with the same
+    // file name (access/policy.md vs data/policy.md) share one stamp, so the
+    // second was skipped as "up to date" and its PDF never produced.
+    const alloc = tst.allocator;
+    var tmp = tst.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmpAbsPath(alloc, &tmp);
+    defer alloc.free(tmp_path);
+
+    try tmp.dir.createDirPath(io, "access");
+    try tmp.dir.createDirPath(io, "data");
+    try tmp.dir.writeFile(io, .{ .sub_path = "access/policy.md", .data = "a" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "data/policy.md", .data = "b" });
+
+    const a_path = try std.fs.path.join(alloc, &.{ tmp_path, "access/policy.md" });
+    defer alloc.free(a_path);
+    const b_path = try std.fs.path.join(alloc, &.{ tmp_path, "data/policy.md" });
+    defer alloc.free(b_path);
+
+    const a_name = try utils.stampName(alloc, a_path);
+    defer alloc.free(a_name);
+    const b_name = try utils.stampName(alloc, b_path);
+    defer alloc.free(b_name);
+    // Distinct keys, and neither contains a path separator.
+    try tst.expect(!std.mem.eql(u8, a_name, b_name));
+    try tst.expect(std.mem.indexOfScalar(u8, a_name, '/') == null);
+
+    // Stamping the first must not mark the second as up to date.
+    utils.writeStamp(io, alloc, tmp_path, a_path);
+    try tst.expect(!utils.stampIsNewer(io, b_path, tmp_path, alloc));
 }
 
 // ============================================================
@@ -517,8 +564,48 @@ test "redact: well-formed block is redacted" {
     defer ts.deinit(tst.allocator);
     try ts.appendSlice(tst.allocator, t);
     try utils.redact(tst.allocator, &ts, true);
-    const expected = [_]u8{'_'} ** t.len;
-    try tst.expectEqualStrings(&expected, ts.items);
+    // The span is masked with solid █ bars; no plaintext and no tags survive.
+    try tst.expect(std.mem.indexOf(u8, ts.items, "sensitive") == null);
+    try tst.expect(std.mem.indexOf(u8, ts.items, "{%") == null);
+    try tst.expect(std.mem.indexOf(u8, ts.items, "█") != null);
+    // No underscore placeholder leaks through (the old two-pass artefact).
+    try tst.expect(std.mem.indexOfScalar(u8, ts.items, '_') == null);
+}
+
+test "redact: whitespace-trim tag variant is still redacted" {
+    // Tera trim markers ({%- ... -%}) must not let a block slip past the
+    // redactor unmasked.
+    const t =
+        \\{%- redact() -%}
+        \\leaked secret value
+        \\{%- end -%}
+    ;
+    var ts = Array(u8).empty;
+    defer ts.deinit(tst.allocator);
+    try ts.appendSlice(tst.allocator, t);
+    try utils.redact(tst.allocator, &ts, true);
+    try tst.expect(std.mem.indexOf(u8, ts.items, "leaked secret") == null);
+    try tst.expect(std.mem.indexOf(u8, ts.items, "█") != null);
+}
+
+test "redact: legitimate underscores in the body survive" {
+    // Only the redacted span is masked; snake_case identifiers, _emphasis_,
+    // and URLs elsewhere keep their underscores intact.
+    const t =
+        \\Set MAX_RETRY_COUNT and read the audit_log at /docs/my_page.
+        \\Use _emphasis_ freely.
+        \\{% redact() %}hide me{% end %}
+    ;
+    var ts = Array(u8).empty;
+    defer ts.deinit(tst.allocator);
+    try ts.appendSlice(tst.allocator, t);
+    try utils.redact(tst.allocator, &ts, true);
+    try tst.expect(std.mem.indexOf(u8, ts.items, "MAX_RETRY_COUNT") != null);
+    try tst.expect(std.mem.indexOf(u8, ts.items, "audit_log") != null);
+    try tst.expect(std.mem.indexOf(u8, ts.items, "my_page") != null);
+    try tst.expect(std.mem.indexOf(u8, ts.items, "_emphasis_") != null);
+    try tst.expect(std.mem.indexOf(u8, ts.items, "hide me") == null);
+    try tst.expect(std.mem.indexOf(u8, ts.items, "█") != null);
 }
 
 test "redact: well-formed block is unredacted when remove=false" {
@@ -595,8 +682,8 @@ test "redact mode: title suffix and content scrubbed" {
     try tst.expect(std.mem.indexOf(u8, fm.title, "(Redacted)") != null);
     // No unprocessed shortcode tags should remain.
     try tst.expect(std.mem.indexOf(u8, contents.items, "{% end %}") == null);
-    // Redacted blocks become underscores, not visible text.
-    try tst.expect(std.mem.indexOf(u8, contents.items, &[_]u8{'_'} ** 10) != null);
+    // Redacted blocks become solid █ bars, not visible text.
+    try tst.expect(std.mem.indexOf(u8, contents.items, "██████████") != null);
 }
 
 // --- draft.png path resolution ---

--- a/src/typst.zig
+++ b/src/typst.zig
@@ -132,6 +132,25 @@ pub fn compile(
     try runTypst(io, env, alloc, typ_abs, out_path, config.root);
 }
 
+/// Compute the output PDF filename for a policy without rendering it. Used to
+/// detect two policies that would resolve to the same filename (same title +
+/// version) before compilation, which would otherwise race to the same path
+/// and silently overwrite one another. Caller owns the returned slice.
+pub fn outputName(io: std.Io, alloc: Allocator, config: Config, input_file: []const u8) ![]u8 {
+    var dir = try std.Io.Dir.cwd().openDir(io, config.root, .{});
+    defer dir.close(io);
+    var file = try dir.openFile(io, input_file, .{ .mode = .read_only });
+    defer file.close(io);
+
+    const raw = try u.readAllAlloc(io, file, alloc, 100_000_000);
+    var contents = Array(u8){ .items = raw, .capacity = raw.len };
+    defer contents.deinit(alloc);
+
+    var fm = try u.get_metadata(alloc, &contents, config);
+    defer fm.deinit(alloc);
+    return fm.filename(alloc);
+}
+
 /// Render a Markdown policy file to a complete Typst source. Split out from
 /// `compile` so tests can assert on the generated markup without a typst
 /// binary. Caller owns the result (free via `Rendered.deinit`).
@@ -168,11 +187,9 @@ pub fn render(
     try u.replace_zola_at(alloc, &contents, config.base_url);
     try u.replace_admonitions(alloc, &contents);
     try u.replace_mermaid(alloc, &contents);
+    // `u.redact` masks redacted spans with solid `█` bars directly (only the
+    // spans, never legitimate underscores elsewhere in the body).
     try u.redact(alloc, &contents, config.redact);
-    // `u.redact` fills redacted blocks with `_` characters, which CommonMark
-    // parses as thematic breaks (→ thin gray lines). Replace them with `█`
-    // (U+2588 FULL BLOCK) so they render as solid black bars.
-    if (config.redact) try u.underscoresToBlocks(alloc, &contents);
 
     // ── 3. Extract frontmatter ───────────────────────────────────────────────
 
@@ -260,12 +277,12 @@ pub fn render(
     const typ_src = try aw.toOwnedSlice();
     errdefer alloc.free(typ_src);
 
-    // ── 6. Sanitise output filename ──────────────────────────────────────────
+    // ── 6. Output filename ────────────────────────────────────────────────────
+    // fm.filename applies the canonical sanitiser (u.sanitizePdfName); no
+    // second pass here, so the name always matches what the site links to.
 
     const out = try fm.filename(alloc);
     errdefer alloc.free(out);
-    std.mem.replaceScalar(u8, out, ' ', '_');
-    sanitizeFilename(out);
 
     return .{ .source = typ_src, .pdf_name = out };
 }
@@ -571,26 +588,6 @@ fn writeVersionHistory(writer: anytype, fm: *zigmark.Frontmatter) !void {
     }
 
     try writer.writeAll(")\n");
-}
-
-// ── Filename helpers ──────────────────────────────────────────────────────────
-
-/// Sanitise an output filename in-place: path separators and unsafe characters
-/// become '_', leading '.' and '..' sequences are defused.
-fn sanitizeFilename(name: []u8) void {
-    var prev_dot = false;
-    for (name, 0..) |*ch, i| {
-        var c = ch.*;
-        if (c == '/' or c == '\\') c = '_';
-        if (!std.ascii.isAlphanumeric(c) and c != '_' and c != '-' and c != '.') c = '_';
-        if (c == '.') {
-            if (i == 0 or prev_dot) {
-                c = '_';
-                prev_dot = false;
-            } else prev_dot = true;
-        } else prev_dot = false;
-        ch.* = c;
-    }
 }
 
 // ── typst subprocess ──────────────────────────────────────────────────────────

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -42,11 +42,15 @@ pub const FrontMatter = struct {
             },
         );
     }
-    /// Generates a PDF filename from the title and most recent version in the front matter.
+    /// Generates a PDF filename from the title and most recent version in the
+    /// front matter. This is the single source of truth for PDF names; the site
+    /// templates mirror the same rule via the `pdf_filename` macro so that the
+    /// links they build resolve to the files produced here. Does not mutate the
+    /// front matter (an earlier version aliased and rewrote `self.title`).
     pub fn filename(self: FrontMatter, a: Allocator) ![]u8 {
-        const tmp = self.title;
-        std.mem.replaceScalar(u8, tmp, ' ', '_');
-        return std.fmt.allocPrint(a, "{s}_-_v{s}.pdf", .{ tmp, self.most_recent_version });
+        const name = try std.fmt.allocPrint(a, "{s}_-_v{s}.pdf", .{ self.title, self.most_recent_version });
+        sanitizePdfName(name);
+        return name;
     }
 
     pub fn deinit(self: *FrontMatter, a: Allocator) void {
@@ -56,9 +60,115 @@ pub const FrontMatter = struct {
     }
 };
 
+/// Canonical PDF-filename sanitiser, applied in-place. This is the one rule the
+/// whole toolchain agrees on; the `pdf_filename` Tera macro replicates it so the
+/// site's download links match the files this binary writes.
+///
+/// Rule: any character that is not ASCII-alphanumeric, `_`, `-`, or `.` becomes
+/// `_` (so spaces, `/`, `(`, `&`, `?`, quotes, etc. are all normalised). A
+/// leading `.` and any doubled `.` are defused so the name can never be `.`,
+/// `..`, or a hidden dotfile.
+pub fn sanitizePdfName(name: []u8) void {
+    var prev_dot = false;
+    for (name, 0..) |*ch, i| {
+        var c = ch.*;
+        if (!std.ascii.isAlphanumeric(c) and c != '_' and c != '-' and c != '.') c = '_';
+        if (c == '.') {
+            if (i == 0 or prev_dot) {
+                c = '_';
+                prev_dot = false;
+            } else prev_dot = true;
+        } else prev_dot = false;
+        ch.* = c;
+    }
+}
+
 /// Parses front matter from a markdown file using zigmark, extracts document
 /// metadata, and returns a FrontMatter struct.  Handles YAML, TOML, JSON, and
 /// ZON front matter; resolves empty arrays without errors (fixes #73).
+/// Normalise a revision's `version` into `buf` as a string. zigmark's YAML
+/// parser returns quoted scalars as `.string` and unquoted numerics as
+/// `.float`/`.integer`, so all three are accepted. Returns null when absent
+/// or an unsupported type.
+fn revisionVersion(obj: anytype, buf: []u8) ?[]const u8 {
+    return switch (obj.get("version") orelse return null) {
+        .string => |s| s,
+        .float => |f| std.fmt.bufPrint(buf, "{d}", .{f}) catch null,
+        .integer => |n| std.fmt.bufPrint(buf, "{d}", .{n}) catch null,
+        else => null,
+    };
+}
+
+/// A revision's `date` as a string (ISO `YYYY-MM-DD`), or null when absent or
+/// not a string. ISO dates order correctly under a plain byte comparison.
+fn revisionDate(obj: anytype) ?[]const u8 {
+    return switch (obj.get("date") orelse return null) {
+        .string => |s| s,
+        else => null,
+    };
+}
+
+/// Order two dotted version strings numerically ("1.9" < "1.10", "9.0" <
+/// "10.0"). Segments that are not integers fall back to a byte comparison so a
+/// version like "1.0-rc1" still orders deterministically. Returns the order of
+/// `x` relative to `y`.
+fn compareVersions(x: []const u8, y: []const u8) std.math.Order {
+    var xi = std.mem.splitScalar(u8, x, '.');
+    var yi = std.mem.splitScalar(u8, y, '.');
+    while (true) {
+        const xs = xi.next();
+        const ys = yi.next();
+        if (xs == null and ys == null) return .eq;
+        // A missing trailing segment counts as 0 so "1.0" == "1".
+        const x_seg = std.mem.trim(u8, xs orelse "0", " ");
+        const y_seg = std.mem.trim(u8, ys orelse "0", " ");
+        const x_num = std.fmt.parseInt(u64, x_seg, 10) catch {
+            const ord = std.mem.order(u8, x_seg, y_seg);
+            if (ord != .eq) return ord;
+            continue;
+        };
+        const y_num = std.fmt.parseInt(u64, y_seg, 10) catch {
+            const ord = std.mem.order(u8, x_seg, y_seg);
+            if (ord != .eq) return ord;
+            continue;
+        };
+        if (x_num != y_num) return if (x_num < y_num) .lt else .gt;
+    }
+}
+
+/// True when revision `new` is more recent than `cur`. Primary key is the
+/// `date` (matching the site, which sorts revisions by date); ties (or missing
+/// dates) fall back to a numeric version comparison. This keeps the PDF's
+/// version label in agreement with the website and never lets "1.10" lose to
+/// "1.9" under a lexicographic compare.
+fn revisionIsNewer(new_obj: anytype, cur_obj: anytype) bool {
+    const new_date = revisionDate(new_obj);
+    const cur_date = revisionDate(cur_obj);
+    if (new_date != null and cur_date != null) {
+        switch (std.mem.order(u8, new_date.?, cur_date.?)) {
+            .gt => return true,
+            .lt => return false,
+            .eq => {},
+        }
+    }
+    var new_buf: [32]u8 = undefined;
+    var cur_buf: [32]u8 = undefined;
+    const new_ver = revisionVersion(new_obj, &new_buf) orelse return false;
+    const cur_ver = revisionVersion(cur_obj, &cur_buf) orelse return true;
+    return compareVersions(new_ver, cur_ver) == .gt;
+}
+
+test "compareVersions orders dotted versions numerically" {
+    try tst.expect(compareVersions("1.9", "1.10") == .lt);
+    try tst.expect(compareVersions("1.10", "1.9") == .gt);
+    try tst.expect(compareVersions("9.0", "10.0") == .lt);
+    try tst.expect(compareVersions("2.0", "2.0") == .eq);
+    try tst.expect(compareVersions("2", "2.0") == .eq);
+    try tst.expect(compareVersions("2.1", "2") == .gt);
+    // A plain lexicographic compare would wrongly rank "1.9" above "1.10".
+    try tst.expect(std.mem.order(u8, "1.9", "1.10") == .gt);
+}
+
 pub fn get_metadata(a: Allocator, txt: *Array(u8), config: anytype) !FrontMatter {
     var fm = try zigmark.Frontmatter.initFromMarkdown(a, txt.items);
     defer fm.deinit();
@@ -83,7 +193,8 @@ pub fn get_metadata(a: Allocator, txt: *Array(u8), config: anytype) !FrontMatter
     };
     if (revisions.len == 0) return error.NoRevisionsInFrontMatter;
 
-    // Find the most recent revision by comparing version strings.
+    // Find the most recent revision by date (with a numeric version tiebreak),
+    // matching the website's date-based selection.
     var most_recent = revisions[0];
     for (revisions[1..]) |rev| {
         const cur_obj = switch (most_recent) {
@@ -94,15 +205,7 @@ pub fn get_metadata(a: Allocator, txt: *Array(u8), config: anytype) !FrontMatter
             .object => |o| o,
             else => continue,
         };
-        const cur_ver = switch (cur_obj.get("version") orelse continue) {
-            .string => |s| s,
-            else => continue,
-        };
-        const new_ver = switch (new_obj.get("version") orelse continue) {
-            .string => |s| s,
-            else => continue,
-        };
-        if (std.mem.order(u8, new_ver, cur_ver) == .gt) {
+        if (revisionIsNewer(new_obj, cur_obj)) {
             most_recent = rev;
         }
     }
@@ -342,9 +445,41 @@ test "FM parse via zigmark reads title from example policy" {
     try tst.expect(fm.get("title") != null);
 }
 
+/// The UTF-8 solid-block character `█` (U+2588) used to mask redacted spans.
+const redaction_block = "█";
+
+/// Build the replacement string for a redacted span: `count` solid `█` blocks
+/// with a break space inserted after every 10 so Typst can wrap the bar within
+/// the text width (a redacted block otherwise becomes one unbreakable "word",
+/// since redaction also replaces the block's internal spaces and newlines).
+/// Caller owns the returned slice.
+fn buildRedactionBar(a: Allocator, count: usize) ![]u8 {
+    var buf = Array(u8).empty;
+    errdefer buf.deinit(a);
+    var n: usize = 0;
+    while (n < count) : (n += 1) {
+        try buf.appendSlice(a, redaction_block);
+        if ((n + 1) % 10 == 0) try buf.append(a, ' ');
+    }
+    return buf.toOwnedSlice(a);
+}
+
+/// Redact `{% redact() %}...{% end %}` shortcode blocks in `txt`.
+///
+/// When `remove` is true the entire block (tags and content) is replaced with
+/// solid `█` bars; when false the tags are stripped and the inner content is
+/// kept. Whitespace-trim tag variants (`{%- redact() -%}`, `{%- end -%}`) are
+/// accepted so trimmed authoring never leaks a block past the redactor. Any
+/// orphaned tag with no matching pair is a hard error (`UnclosedRedaction`) so
+/// a malformed block can never pass through silently into a `--redact` PDF.
+///
+/// Redacted spans are masked with `█` directly rather than an underscore
+/// placeholder: underscores collide with legitimate content (snake_case
+/// identifiers, `_emphasis_`, URLs) and previously corrupted every literal
+/// underscore in the document when converted to bars in a second pass.
 pub fn redact(a: Allocator, txt: *Array(u8), remove: bool) !void {
-    const r: mvzr.Regex = mvzr.compile("\\{%\\s*redact\\(\\)\\s*%\\}.+?\\{%\\s*end\\s*%\\}").?;
-    const unclosed = mvzr.compile("\\{%\\s*(redact\\(\\)|end)\\s*%\\}").?;
+    const r: mvzr.Regex = mvzr.compile("\\{%-?\\s*redact\\(\\)\\s*-?%\\}.+?\\{%-?\\s*end\\s*-?%\\}").?;
+    const unclosed = mvzr.compile("\\{%-?\\s*(redact\\(\\)|end)\\s*-?%\\}").?;
 
     if (!r.isMatch(txt.items)) {
         // No complete pair — fail loudly if any orphaned tag is present.
@@ -359,11 +494,9 @@ pub fn redact(a: Allocator, txt: *Array(u8), remove: bool) !void {
         const s = std.mem.indexOf(u8, m.slice, "%}") orelse return error.InvalidShortCode;
         const e = std.mem.lastIndexOf(u8, m.slice, "{%") orelse return error.InvalidShortCode;
         const inner = m.slice[s + 2 .. e - 1];
-        const replace = if (remove) blk: {
-            const replace = try a.alloc(u8, m.slice.len);
-            @memset(replace, '_');
-            break :blk replace;
-        } else blk: {
+        const replace = if (remove)
+            try buildRedactionBar(a, m.slice.len)
+        else blk: {
             const replace = try a.alloc(u8, m.slice.len);
             @memset(replace, ' ');
             @memcpy(replace[0..inner.len], inner);
@@ -379,120 +512,6 @@ pub fn redact(a: Allocator, txt: *Array(u8), remove: bool) !void {
 
     // After processing all matched pairs, any remaining tag is an orphan.
     if (unclosed.isMatch(txt.items)) return error.UnclosedRedaction;
-}
-
-/// Replace `_` characters in the **body** of `txt` (after the frontmatter) with
-/// the UTF-8 solid-block character `█` (U+2588).
-///
-/// `redact` fills redacted spans with underscores.  In CommonMark, a run of
-/// three or more `_` on its own line is a thematic break, so zigmark renders it
-/// as a thin gray rule.  Replacing with `█` produces proper black-bar redaction
-/// marks without any special Markdown meaning.
-///
-/// Only the body is processed; the frontmatter block (keys like `last_reviewed`,
-/// `major_revisions`) must remain intact for the later metadata extraction pass.
-pub fn underscoresToBlocks(alloc: Allocator, txt: *Array(u8)) !void {
-    const block = "█"; // 3-byte UTF-8: 0xE2 0x96 0x88
-    if (std.mem.indexOfScalar(u8, txt.items, '_') == null) return;
-
-    // Locate the end of the frontmatter so we leave it untouched. The closing
-    // delimiter only counts when it is a whole line ("---" at line start,
-    // followed by a newline or EOF) — a "---" inside a frontmatter value must
-    // not end the protected region early, or later underscores in keys like
-    // `last_reviewed` would be corrupted.
-    const content = txt.items;
-    const body_start: usize = blk: {
-        if (content.len < 4) break :blk 0;
-        const delim: []const u8 = switch (content[0]) {
-            '-' => "---",
-            '+' => "+++",
-            else => break :blk 0,
-        };
-        var search: usize = 3;
-        while (std.mem.indexOfPos(u8, content, search, delim)) |idx| : (search = idx + 1) {
-            if (content[idx - 1] != '\n') continue;
-            const line_end = idx + delim.len;
-            if (line_end >= content.len) break :blk line_end;
-            if (content[line_end] == '\n') break :blk line_end + 1;
-            if (content[line_end] == '\r' and line_end + 1 < content.len and content[line_end + 1] == '\n')
-                break :blk line_end + 2;
-        }
-        break :blk 0;
-    };
-
-    var aw: std.Io.Writer.Allocating = .init(alloc);
-    defer aw.deinit();
-    // Copy the frontmatter verbatim.
-    try aw.writer.writeAll(content[0..body_start]);
-    // Replace underscores in the body with █.
-    // Insert a space every 10 blocks so Typst can wrap the bar within the text
-    // width (redact replaces spaces too, producing one unbreakable "word").
-    var block_count: usize = 0;
-    for (content[body_start..]) |c| {
-        if (c == '_') {
-            try aw.writer.writeAll(block);
-            block_count += 1;
-            if (block_count % 10 == 0) try aw.writer.writeByte(' ');
-        } else {
-            block_count = 0;
-            try aw.writer.writeByte(c);
-        }
-    }
-    const new_bytes = try aw.toOwnedSlice();
-    txt.deinit(alloc);
-    txt.* = Array(u8){ .items = new_bytes, .capacity = new_bytes.len };
-}
-
-test "underscoresToBlocks replaces body underscores with solid blocks" {
-    const allocator = tst.allocator;
-    var arr = Array(u8).empty;
-    defer arr.deinit(allocator);
-    try arr.appendSlice(allocator, "some ____ text");
-
-    try underscoresToBlocks(allocator, &arr);
-    try tst.expectEqualStrings("some ████ text", arr.items);
-}
-
-test "underscoresToBlocks leaves frontmatter untouched" {
-    const allocator = tst.allocator;
-    var arr = Array(u8).empty;
-    defer arr.deinit(allocator);
-    try arr.appendSlice(allocator, "---\nlast_reviewed: 2026-01-01\n---\nbody __ here");
-
-    try underscoresToBlocks(allocator, &arr);
-    try tst.expectEqualStrings("---\nlast_reviewed: 2026-01-01\n---\nbody ██ here", arr.items);
-}
-
-test "underscoresToBlocks ignores a --- inside a frontmatter value" {
-    const allocator = tst.allocator;
-    var arr = Array(u8).empty;
-    defer arr.deinit(allocator);
-    // The "---" in the description must not end the protected region:
-    // last_reviewed's underscore has to survive.
-    try arr.appendSlice(allocator, "---\ndescription: \"a --- b\"\nlast_reviewed: 2026-01-01\n---\nbody __ here");
-
-    try underscoresToBlocks(allocator, &arr);
-    try tst.expectEqualStrings("---\ndescription: \"a --- b\"\nlast_reviewed: 2026-01-01\n---\nbody ██ here", arr.items);
-}
-
-test "underscoresToBlocks inserts a break space every 10 blocks" {
-    const allocator = tst.allocator;
-    var arr = Array(u8).empty;
-    defer arr.deinit(allocator);
-    try arr.appendSlice(allocator, "_" ** 12);
-
-    try underscoresToBlocks(allocator, &arr);
-    try tst.expectEqualStrings("██████████ ██", arr.items);
-}
-
-test "underscoresToBlocks is a no-op without underscores" {
-    const allocator = tst.allocator;
-    var arr = Array(u8).empty;
-    defer arr.deinit(allocator);
-    try arr.appendSlice(allocator, "clean text");
-
-    try underscoresToBlocks(allocator, &arr);
-    try tst.expectEqualStrings("clean text", arr.items);
 }
 
 /// Returns true when `name` resolves to an executable on the PATH.
@@ -513,12 +532,29 @@ pub fn executableInPath(io: std.Io, env: *std.process.Environ.Map, name: []const
 // Stamp-file caching helpers
 // ============================================================
 
+/// Derive a stamp filename that is unique to the policy's full relative path,
+/// not just its basename. Two policies with the same file name in different
+/// directories (`access/policy.md` vs `data/policy.md`) must not share a stamp,
+/// or the second would be skipped as "up to date" and its PDF never produced.
+/// Path separators become `_`; the trailing `.md` is dropped so the stamp does
+/// not look like a Markdown file. The result is a single flat filename.
+pub fn stampName(alloc: Allocator, input_path: []const u8) ![]u8 {
+    var rel = std.mem.trimStart(u8, input_path, "/\\");
+    if (std.mem.endsWith(u8, rel, ".md")) rel = rel[0 .. rel.len - 3];
+    const key = try alloc.dupe(u8, rel);
+    for (key) |*c| {
+        if (c.* == '/' or c.* == '\\') c.* = '_';
+    }
+    return key;
+}
+
 /// Returns true if the per-policy stamp file is newer than the source file,
 /// meaning the PDF is already up to date and compilation can be skipped.
 /// Returns false on any IO error so the policy is always rebuilt on doubt.
 pub fn stampIsNewer(io: std.Io, input_path: []const u8, stamps_dir: []const u8, alloc: Allocator) bool {
-    const stem = std.fs.path.stem(std.fs.path.basename(input_path));
-    const stamp_path = std.fs.path.join(alloc, &.{ stamps_dir, stem }) catch return false;
+    const name = stampName(alloc, input_path) catch return false;
+    defer alloc.free(name);
+    const stamp_path = std.fs.path.join(alloc, &.{ stamps_dir, name }) catch return false;
     defer alloc.free(stamp_path);
 
     const src = std.Io.Dir.openFileAbsolute(io, input_path, .{}) catch return false;
@@ -535,11 +571,30 @@ pub fn stampIsNewer(io: std.Io, input_path: []const u8, stamps_dir: []const u8, 
 /// Touches a stamp file for `input_path` inside `stamps_dir` to record that
 /// compilation succeeded. Failures are non-fatal (worst case: needless rebuild).
 pub fn writeStamp(io: std.Io, alloc: Allocator, stamps_dir: []const u8, input_path: []const u8) void {
-    const stem = std.fs.path.stem(std.fs.path.basename(input_path));
-    const stamp_path = std.fs.path.join(alloc, &.{ stamps_dir, stem }) catch return;
+    const name = stampName(alloc, input_path) catch return;
+    defer alloc.free(name);
+    const stamp_path = std.fs.path.join(alloc, &.{ stamps_dir, name }) catch return;
     defer alloc.free(stamp_path);
     const f = std.Io.Dir.cwd().createFile(io, stamp_path, .{ .truncate = true }) catch return;
     f.close(io);
+}
+
+/// Returns true when the policy at `dir`/`sub_path` is marked `draft: true` in
+/// its front matter. Draft policies are excluded from PDF generation (Zola
+/// likewise omits them from the site), so an unapproved draft never ships an
+/// official-looking PDF at a guessable URL. Returns false on any read/parse
+/// error so a policy is never silently dropped by mistake — a malformed file
+/// surfaces later as a real compile error instead.
+pub fn isDraftPolicy(io: std.Io, alloc: Allocator, dir: std.Io.Dir, sub_path: []const u8) bool {
+    const content = dir.readFileAlloc(io, sub_path, alloc, .limited(10 * 1024 * 1024)) catch return false;
+    defer alloc.free(content);
+    var fm = zigmark.Frontmatter.initFromMarkdown(alloc, content) catch return false;
+    defer fm.deinit();
+    return switch (fm.get("draft") orelse return false) {
+        .bool => |b| b,
+        .string => |s| std.ascii.eqlIgnoreCase(s, "true"),
+        else => false,
+    };
 }
 
 /// Converts {% admonition(type="...", title="...") %}...{% end %} shortcodes

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,6 +9,7 @@
 {% import 'macros/docs-edit-page.html' as macros_edit_page -%}
 {% import 'macros/docs-navigation.html' as macros_navigation -%}
 {% import 'macros/docs-toc.html' as macros_toc -%}
+{% import 'macros/pdf-filename.html' as macros_pdf -%}
 
 {% if not config.extra.easydocs_uglyurls or config.mode == "serve" or
 config.mode == "Serve" -%}

--- a/templates/macros/header.html
+++ b/templates/macros/header.html
@@ -1,10 +1,12 @@
 {% macro header(current_section) %}
 <header class="navbar fixed-top navbar-expand-md navbar-light my-auto">
 	<div class="container">
-		{# <input class="menu-btn order-0" type="checkbox" id="menu-btn"> #}
-		<label class="menu-icon d-md-none" for="menu-btn"><span
-				class="navicon"></span>
-		</label>
+		<button class="navbar-toggler d-md-none order-0" type="button"
+			data-bs-toggle="collapse" data-bs-target="#navbarMain"
+			aria-controls="navbarMain" aria-expanded="false"
+			aria-label="Toggle navigation">
+			<span class="navbar-toggler-icon"></span>
+		</button>
 		<a class="navbar-brand order-1 order-md-0 me-auto"
 			href="{{ config.base_url | safe }}"><img class="brand-logo"
 				src="{{ get_url(path=config.extra.menu.logo) }}">{{
@@ -38,7 +40,7 @@
 			{% endfor %}
 			{% endif %}
 		</ul>
-		<div class="collapse navbar-collapse order-4 order-md-1">
+		<div id="navbarMain" class="collapse navbar-collapse order-4 order-md-1">
 			<ul class="navbar-nav main-nav me-auto order-5 order-md-2">
 				{% if lang == config.default_language %}
 				{% set rootsectionpath = "_index.md" %}

--- a/templates/macros/pdf-filename.html
+++ b/templates/macros/pdf-filename.html
@@ -1,0 +1,39 @@
+{# PDF filename slug — mirrors the canonical sanitiser in the policypress
+   binary (u.sanitizePdfName in src/utils.zig). Every character that is not
+   ASCII-alphanumeric, "_", "-", or "." becomes "_", so the download links the
+   site builds resolve to the files the binary actually writes. Keep the two
+   rules in lock-step: any change here needs the same change in sanitizePdfName
+   (and the golden test in src/test.zig). #}
+{% macro slug(title) -%}
+{{ title
+  | replace(from=" ", to="_")
+  | replace(from="!", to="_")
+  | replace(from='"', to="_")
+  | replace(from="#", to="_")
+  | replace(from="$", to="_")
+  | replace(from="%", to="_")
+  | replace(from="&", to="_")
+  | replace(from="'", to="_")
+  | replace(from="(", to="_")
+  | replace(from=")", to="_")
+  | replace(from="*", to="_")
+  | replace(from="+", to="_")
+  | replace(from=",", to="_")
+  | replace(from="/", to="_")
+  | replace(from=":", to="_")
+  | replace(from=";", to="_")
+  | replace(from="<", to="_")
+  | replace(from="=", to="_")
+  | replace(from=">", to="_")
+  | replace(from="?", to="_")
+  | replace(from="@", to="_")
+  | replace(from="[", to="_")
+  | replace(from="\\", to="_")
+  | replace(from="]", to="_")
+  | replace(from="^", to="_")
+  | replace(from="`", to="_")
+  | replace(from="{", to="_")
+  | replace(from="|", to="_")
+  | replace(from="}", to="_")
+  | replace(from="~", to="_") }}
+{%- endmacro slug %}

--- a/templates/policies/page.html
+++ b/templates/policies/page.html
@@ -10,7 +10,7 @@
 {# Link to the PDF version for print and for discovery #}
 {% set versions = page.extra.major_revisions | sort(attribute="date") | reverse %}
 {% set current_version = versions | first %}
-{%- set title_slug = page.title | replace(from=" ", to="_") -%}
+{%- set title_slug = macros_pdf::slug(title=page.title) | trim -%}
 {%- if config.extra.policypress.redact_web -%}
   {%- set pdf_official = title_slug ~ "__Redacted__-_v" ~ current_version.version ~ ".pdf" -%}
 {%- else -%}
@@ -44,8 +44,8 @@ reverse %}
 {% set today = now() | date(format="%s") | int %}
 {% set review_overdue = (today - last_reviewed_ts) > 31557600 %}
 
-{%- set title_slug = page.title | replace(from=" ", to="_") -%}
-{# policypress sanitizes '(' and ')' to '_', so (Redacted) becomes __Redacted__ #}
+{%- set title_slug = macros_pdf::slug(title=page.title) | trim -%}
+{# The binary sanitises '(' and ')' to '_', so (Redacted) becomes __Redacted__ #}
 {%- if config.extra.policypress.redact_web -%}
   {%- set pdf_official = title_slug ~ "__Redacted__-_v" ~ current_version.version ~ ".pdf" -%}
   {%- set pdf_draft = title_slug ~ "__Redacted___Draft__-_v" ~ current_version.version ~ ".pdf" -%}

--- a/templates/shortcodes/redact.html
+++ b/templates/shortcodes/redact.html
@@ -1,6 +1,9 @@
 {% set redact_web = config.extra.policypress.redact_web or false %}
-{% if redact_web %}
-<span class="redaction" role="img" aria-label="[redacted]"></span>
-{% else %}
+{%- if redact_web -%}
+{#- Mask server-side: emit solid bars sized to the content, never the body
+    itself. The text must not reach the page source, the client-side search
+    index, or the RSS/Atom feed. -#}
+<span class="redaction" role="img" aria-label="[redacted]">{% for _ in range(end=body | length) %}█{% endfor %}</span>
+{%- else -%}
 {{ body | safe }}
-{% endif %}
+{%- endif -%}

--- a/tests/redaction-leak-check.sh
+++ b/tests/redaction-leak-check.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Redaction leak check (integration).
+#
+# Builds the demo site and the redacted PDFs, then asserts that content wrapped
+# in {% redact() %} ... {% end %} never survives into any published artifact:
+#   - the site HTML, client-side search index, and RSS/Atom/sitemap feeds
+#     (with redact_web = true the shortcode must emit bars, never the text);
+#   - the policypress output directory must contain PDFs only — no Markdown or
+#     Typst work files.
+#
+# The PDF text layer is verified in the Zig test suite (the "typst source:
+# redaction produces solid bars" golden test), which needs no external tools;
+# if pdftotext is available here we additionally scan the rendered PDFs.
+#
+# Run from the repo root, inside the devshell:  bash tests/redaction-leak-check.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+fail=0
+tmp_pdfs="$(mktemp -d)"
+site_out="public"
+trap 'rm -rf "$tmp_pdfs"' EXIT
+
+# Sentinel strings that live inside {% redact() %} blocks in the demo content.
+# Each MUST be absent from every published artifact.
+sentinels=(
+  "Customer data, financial records, trade secrets"
+  "sensitive information that should not be disclosed"
+)
+
+echo "▸ Building site (zola build)…"
+# The action copies theme shortcodes to the site root; mirror that so a
+# standalone build resolves the redact shortcode.
+mkdir -p templates/shortcodes
+zola build >/dev/null
+
+echo "▸ Scanning site output for redacted content…"
+for s in "${sentinels[@]}"; do
+  if grep -rqF "$s" "$site_out"; then
+    echo "  ✗ LEAK: '$s' found in $site_out:"
+    grep -rlF "$s" "$site_out" | sed 's/^/      /'
+    fail=1
+  else
+    echo "  ✓ absent: '$s'"
+  fi
+done
+
+# A rendered redaction bar must exist (proves the shortcode ran, not that the
+# block was simply dropped).
+if ! grep -rq 'class="redaction"' "$site_out"/policies; then
+  echo "  ✗ no redaction bars rendered — is redact_web enabled and are there redact blocks?"
+  fail=1
+else
+  echo "  ✓ redaction bars present in policy pages"
+fi
+
+echo "▸ Building redacted PDFs to a scratch dir…"
+./zig-out/bin/policypress -c config.toml -o "$tmp_pdfs" --redact >/dev/null 2>&1 \
+  || { echo "  ✗ policypress --redact failed"; exit 1; }
+
+echo "▸ Checking the PDF output dir holds PDFs only (no work files)…"
+# Ignore the internal incremental-build cache (.pp-stamps-*); it holds empty
+# touch files, not content. The check targets accidental work-file output
+# (stray .md source or .typ intermediates) alongside the PDFs.
+strays="$(find "$tmp_pdfs" -type f ! -name '*.pdf' -not -path '*/.pp-stamps-*' 2>/dev/null || true)"
+if [ -n "$strays" ]; then
+  echo "  ✗ non-PDF work files written to the output dir:"
+  echo "$strays" | sed 's/^/      /'
+  fail=1
+else
+  echo "  ✓ only PDFs in the output dir"
+fi
+
+if command -v pdftotext >/dev/null 2>&1; then
+  echo "▸ Scanning redacted PDFs' text layer…"
+  for pdf in "$tmp_pdfs"/*.pdf; do
+    [ -e "$pdf" ] || continue
+    text="$(pdftotext "$pdf" - 2>/dev/null || true)"
+    for s in "${sentinels[@]}"; do
+      if printf '%s' "$text" | grep -qF "$s"; then
+        echo "  ✗ LEAK: '$s' in $(basename "$pdf")"
+        fail=1
+      fi
+    done
+  done
+  [ "$fail" -eq 0 ] && echo "  ✓ no sentinels in any redacted PDF"
+else
+  echo "▸ pdftotext not available — PDF text layer covered by the Zig golden test."
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "✗ redaction leak check FAILED"
+  exit 1
+fi
+echo "✓ redaction leak check passed"


### PR DESCRIPTION
## Context

Follow-up to the whole-project review (three personas: security/architecture, UX/marketing, end-user compliance manager + accessibility). This PR lands the **redaction hardening** (the known v2 launch blocker, subject of the recent security advisory) plus the **verified correctness fixes** from that review. Larger UX/marketing/accessibility items and the GRC `[^SCF:GOV-01]` design remain tracked in the review notes for the v2 gate.

## Redaction (advisory follow-up)

- **Web "redaction" was cosmetic.** With `redact_web = true`, `redact.html` shipped the real text (CSS-hidden), so redacted content leaked into the page source, the client-side search index, and the RSS/Atom feed. It now emits proportional `█` bars **server-side** and never the body. Verified: the demo build's redact sentinels ("Customer data, financial records", …) are absent from all of `public/`.
- **Underscore corruption.** `underscoresToBlocks` turned *every* literal `_` in the body into `█` in redacted PDFs (snake_case, `_emphasis_`, URLs). `redact()` now masks spans with `█` directly and that lossy second pass is gone.
- **Trim-syntax gap.** `redact()` and its orphan-tag guard now accept `{%- … -%}`, so a trimmed block can't slip past unmasked. (Builds on the `UnclosedRedaction` guard already in the tree.)

## Correctness

- **Version selection** is now date-primary with a numeric dotted-version tiebreak, matching the site — `1.10` no longer loses to `1.9`, and the PDF/site versions agree.
- **Stamp cache** is keyed by full relative path, not basename — two same-named policies in different dirs no longer share a stamp (one was silently skipped, exit 0, PDF missing).
- **Duplicate output names** now fail the build (naming both policies) instead of silently overwriting one PDF.
- **PDF filename contract** has one source of truth (`filename()` + canonical `sanitizePdfName`); a `pdf-filename` Tera macro mirrors it so the site's download links resolve to the files produced. `filename()` no longer mutates the front matter.
- **`draft: true` policies** are skipped in PDF generation (matching Zola and the docs), so an unapproved draft doesn't get an official-looking PDF at a guessable URL.
- **Mobile nav** uses a real Bootstrap toggler wired to the existing collapse polyfill — nav and search are reachable below the `md` breakpoint again.

## Supply chain

- The composite action downloads the release binary for the **exact pinned ref** (not `latest`), verifies it against a published `SHA256SUMS.txt`, and falls back to a source build; `ci.yml` now publishes the checksums.
- Action inputs are passed via `env` instead of `${{ }}`-interpolation into the run script, closing a shell-injection surface (e.g. `base_url`).

## Tests / verification

- New Zig tests: redact trim-variant, underscore preservation, golden no-leak on rendered Typst source, version comparison, and a same-name-different-dir stamp regression. `zig build test` green.
- `tests/redaction-leak-check.sh` builds the demo site + redacted PDFs and asserts no redact-block content survives (site HTML, search index, feeds) and the PDF output dir holds PDFs only; wired into CI on Linux.
- Verified end-to-end locally: site leak check clean, PDF filenames match the site's hrefs, draft policy skipped, duplicate titles rejected, mobile toggler renders.

## Notes

- Stale, untracked, gitignored `static/pdfs/750207_*.md` (pandoc-era) exist in some working trees and are copied into `public/` by Zola. They don't ship (gitignored, absent from fresh checkouts) and current code doesn't produce them; worth deleting locally.
- The `pdf-filename` macro faithfully mirrors the sanitiser for ASCII; non-ASCII title characters remain a residual edge case (documented in the macro).
