### PR TITLE
fix: flag raw HTML in policy bodies (#117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ keys) is considered stable.
 
 ## [Unreleased]
 
+### Added
+
+- **Raw HTML in policy bodies is now flagged by the build pre-flight** (#117).
+  The website renders raw/inline HTML but the PDF pipeline (zigmark → Typst)
+  silently drops it, so a site and its audit PDF could diverge without warning.
+  The pre-flight now parses each policy body and reports raw HTML as
+  audit-critical: a warning by default, fatal with `--strict`. Detection is
+  AST-based, so `<div>` inside a code fence or inline code and `<user@host>`
+  autolinks never false-positive. HTML examples belong in fenced code blocks;
+  site-only pages (the guides) may still use HTML since only the policy
+  directory is rendered to PDF.
+
 ## [1.4.2] - 2026-07-06
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ PDFs are named `{Title}_-_v{version}.pdf`. With `redact_mode: true`, the name be
 
 PDFs are generated with [Typst](https://typst.app/): markdown is rendered to Typst markup in-process ([zigmark](https://github.com/sc2in/zigmark)), mermaid diagrams become inline SVG via [pozeiden](https://github.com/sc2in/pozeiden), and the layout matches the classic [Eisvogel](https://github.com/Wandmalfarbe/pandoc-latex-template) look. The only external tool is the `typst` binary (bundled in the devshell and GitHub Action; on Windows install it with `winget install Typst.Typst` - without the Source Sans 3 font typst falls back to its embedded fonts, a cosmetic difference only).
 
+Keep policies in **pure Markdown**. Raw or inline HTML renders on the website but the PDF pipeline silently drops it, so the two artifacts would diverge. The build flags raw HTML in any policy body as audit-critical - a warning by default, fatal with `--strict`. To show HTML as an example, put it in a fenced code block or inline code. Site-only pages (such as the guides on this site) may use HTML freely; only the policy directory is rendered to PDF.
+
 ## Compliance reports
 
 The site includes optional compliance coverage views. To enable them, add your control data files and configure the paths:

--- a/content/guides/writing-policies.md
+++ b/content/guides/writing-policies.md
@@ -73,6 +73,8 @@ A well-structured policy has these sections, roughly in order:
 
 Not every policy needs every section. Purpose/Scope and Policy Statements are always required.
 
+**No raw HTML.** Policies must be pure Markdown. Raw or inline HTML renders on the website but is silently dropped from the PDF, so the two artifacts would diverge - the build flags it as audit-critical (fatal with `--strict`). To show HTML as an example, put it in a fenced code block or inline code.
+
 ## Shortcodes
 
 PolicyPress provides a few shortcodes for common patterns.

--- a/src/config.zig
+++ b/src/config.zig
@@ -208,15 +208,18 @@ pub const Config = struct {
         // _ = frontMatter.get("date") orelse return error.NoDateInFrontMatter;
     }
 
-    /// Severity of a policy's front-matter problems.
+    /// Severity of a policy's validation problems.
     pub const IssueKind = enum { none, advisory, critical };
 
-    /// Validate one policy file's front matter without stopping the build.
-    /// Logs the specific problem and classifies it: a missing `description`
-    /// is advisory (it feeds teasers/SEO, not the audit trail); anything that
-    /// undermines the audit record (title, approvals, revision dates/versions,
-    /// or an unparseable file) is critical. The caller decides whether critical
-    /// issues abort the build (see `--strict`). `path` is resolved from cwd.
+    /// Validate one policy file without stopping the build. Checks front matter
+    /// and the Markdown body, logging each specific problem and classifying it.
+    /// A missing `description` is advisory (it feeds teasers/SEO, not the audit
+    /// trail); anything that undermines the audit record is critical: bad front
+    /// matter (title, approvals, revision dates/versions, an unparseable file)
+    /// or raw HTML in the body (the website renders it but the Typst/PDF path
+    /// silently drops it, so the two artifacts would diverge — see
+    /// `reviewPolicyBody`). The caller decides whether critical issues abort the
+    /// build (see `--strict`). `path` is resolved from cwd.
     pub fn reviewPolicyFile(self: Config, io: std.Io, alloc: Allocator, path: []const u8) IssueKind {
         const content = std.Io.Dir.cwd().readFileAlloc(io, path, alloc, .limited(10 * 1024 * 1024)) catch |err| {
             conflog.warn("{s}: cannot read for validation: {s}", .{ path, @errorName(err) });
@@ -233,16 +236,128 @@ pub const Config = struct {
         self.validateFrontMatter(frontMatter) catch |err| switch (err) {
             error.NoDescriptionInFrontMatter, error.NoDescriptionForRevision => {
                 conflog.warn("{s}: missing description (advisory)", .{path});
-                return .advisory;
+                // A body problem outranks the advisory. IssueKind is ordered
+                // none < advisory < critical, so take the more severe of the two.
+                const body = reviewPolicyBody(alloc, path, content);
+                return if (@intFromEnum(body) > @intFromEnum(IssueKind.advisory)) body else .advisory;
             },
             else => {
                 conflog.warn("{s}: {s}", .{ path, @errorName(err) });
                 return .critical;
             },
         };
+        return reviewPolicyBody(alloc, path, content);
+    }
+
+    /// Check the Markdown body for constructs that silently diverge between the
+    /// website and the PDF. Currently one rule: raw or inline HTML, which Zola
+    /// renders on the site (`page.content | safe`) but zigmark's Typst renderer
+    /// omits (`renderers/typst.zig` drops `html_block`/`html_in_line`), so a PDF
+    /// would be missing content the website shows. Critical, because a divergent
+    /// audit record is an integrity failure. Detection is AST-based, so `<div>`
+    /// inside a code fence/span and `<user@host>` autolinks never false-positive.
+    fn reviewPolicyBody(alloc: Allocator, path: []const u8, content: []const u8) IssueKind {
+        const finding = findRawHtml(alloc, content) catch |err| {
+            conflog.warn("{s}: cannot parse body for validation: {s}", .{ path, @errorName(err) });
+            return .critical;
+        };
+        if (finding) |f| {
+            defer f.deinit(alloc);
+            conflog.warn(
+                "{s}: raw HTML in policy body ('{s}'): the website renders it but it is silently dropped from the PDF; remove it or fence it as a code example",
+                .{ path, f.snippet },
+            );
+            return .critical;
+        }
         return .none;
     }
+
+    /// Whether the dropped HTML was a block (`<div>…</div>`) or inline (`<br>`).
+    pub const RawHtmlKind = enum { block, in_line };
+
+    /// A raw-HTML occurrence in a Markdown body that the Typst renderer would
+    /// silently drop.
+    pub const RawHtmlFinding = struct {
+        kind: RawHtmlKind,
+        /// Owned, truncated copy of the offending markup; caller frees.
+        snippet: []u8,
+
+        pub fn deinit(self: RawHtmlFinding, alloc: Allocator) void {
+            alloc.free(self.snippet);
+        }
+    };
+
+    /// Parse `content` (frontmatter included — the parser skips it exactly like
+    /// the PDF render path in `typst.zig`) and return the first raw/inline HTML
+    /// node, or null when the body has none. AST-based via zigmark's own parser,
+    /// so it matches precisely what the renderer would drop.
+    pub fn findRawHtml(alloc: Allocator, content: []const u8) !?RawHtmlFinding {
+        var parser = zigmark.Parser.init();
+        defer parser.deinit(alloc);
+        var doc = try parser.parseMarkdown(alloc, content);
+        defer doc.deinit(alloc);
+
+        const hit = firstRawHtmlInBlocks(doc.children.items) orelse return null;
+
+        // Report the first line only, capped at 80 bytes, without splitting a
+        // UTF-8 sequence: enough for the author to locate the tag.
+        var snip = std.mem.trim(u8, hit.content, " \t\r\n");
+        if (std.mem.indexOfScalar(u8, snip, '\n')) |nl| snip = snip[0..nl];
+        var end = @min(snip.len, 80);
+        while (end < snip.len and (snip[end] & 0xC0) == 0x80) end -= 1;
+        return .{ .kind = hit.kind, .snippet = try alloc.dupe(u8, snip[0..end]) };
+    }
 };
+
+/// Borrowed reference to a raw-HTML node in a parsed document. `content` points
+/// into the `Document`, so callers must copy it out before the document is freed.
+const RawHtmlRef = struct {
+    kind: Config.RawHtmlKind,
+    content: []const u8,
+};
+
+/// Depth-first search for the first raw HTML node reachable from `blocks`.
+/// Switches are exhaustive on purpose: if a future zigmark bump adds a block
+/// kind, this fails to compile so the rule gets revisited.
+fn firstRawHtmlInBlocks(blocks: []const zigmark.AST.Block) ?RawHtmlRef {
+    for (blocks) |*block| switch (block.*) {
+        .html_block => |hb| return .{ .kind = .block, .content = hb.content },
+        .paragraph => |p| if (firstRawHtmlInInlines(p.children.items)) |f| return f,
+        .heading => |h| if (firstRawHtmlInInlines(h.children.items)) |f| return f,
+        .blockquote => |bq| if (firstRawHtmlInBlocks(bq.children.items)) |f| return f,
+        .footnote_definition => |fd| if (firstRawHtmlInBlocks(fd.children.items)) |f| return f,
+        .list => |l| for (l.items.items) |*item| {
+            if (firstRawHtmlInBlocks(item.children.items)) |f| return f;
+        },
+        .table => |t| {
+            for (t.header.cells.items) |*cell| {
+                if (firstRawHtmlInInlines(cell.children.items)) |f| return f;
+            }
+            for (t.body.items) |*row| for (row.cells.items) |*cell| {
+                if (firstRawHtmlInInlines(cell.children.items)) |f| return f;
+            };
+        },
+        // Leaf blocks with no raw-HTML nodes. Code blocks are excluded on
+        // purpose: `<div>` inside a fence is content, not markup.
+        .code_block, .fenced_code_block, .thematic_break => {},
+    };
+    return null;
+}
+
+/// Depth-first search for the first raw inline HTML reachable from `inlines`.
+fn firstRawHtmlInInlines(inlines: []const zigmark.AST.Inline) ?RawHtmlRef {
+    for (inlines) |*il| switch (il.*) {
+        .html_in_line => |h| return .{ .kind = .in_line, .content = h.content },
+        .emphasis => |e| if (firstRawHtmlInInlines(e.children.items)) |f| return f,
+        .strong => |s| if (firstRawHtmlInInlines(s.children.items)) |f| return f,
+        .strikethrough => |s| if (firstRawHtmlInInlines(s.children.items)) |f| return f,
+        .link => |l| if (firstRawHtmlInInlines(l.children.items)) |f| return f,
+        // Leaf inlines. `autolink` is deliberately treated as non-HTML:
+        // `<user@host>` / `<https://…>` are autolinks, which the PDF renders.
+        .text, .code_span, .image, .autolink, .footnote_reference, .hard_break, .soft_break => {},
+    };
+    return null;
+}
 
 pub fn main(init: std.process.Init) !void {
     const io = init.io;

--- a/src/main.zig
+++ b/src/main.zig
@@ -224,7 +224,7 @@ fn runBuild(io: std.Io, env: *EnvMap, alloc: Allocator, args: []const [:0]const 
         \\--no-draft             Do not add draft watermark to output (overrides config.toml).
         \\--redact               Redact content within redaction tags (overrides config.toml).
         \\--no-redact            Do not redact text within redaction tags (overrides config.toml).
-        \\--strict               Fail the build on audit-critical front-matter problems.
+        \\--strict               Fail the build on audit-critical policy problems (front matter, raw HTML in bodies).
         \\-v, --verbose          Show debug output (typst invocations, file paths).
         \\-q, --quiet            Suppress progress output; show errors only.
         \\    --json             Emit log output as JSON lines (for CI).
@@ -455,13 +455,13 @@ fn runBuild(io: std.Io, env: *EnvMap, alloc: Allocator, args: []const [:0]const 
         }
         if (critical + advisory > 0) {
             std.log.warn(
-                "policypress: front-matter validation found {d} audit-critical and {d} advisory issue(s).",
+                "policypress: policy validation found {d} audit-critical and {d} advisory issue(s).",
                 .{ critical, advisory },
             );
         }
         if (strict and critical > 0) {
             std.log.err(
-                "policypress: {d} audit-critical front-matter problem(s); aborting (--strict).",
+                "policypress: {d} audit-critical policy problem(s); aborting (--strict).",
                 .{critical},
             );
             return error.ValidationFailed;

--- a/src/test.zig
+++ b/src/test.zig
@@ -540,6 +540,134 @@ test "empty frontmatter: blank approved_by → EmptyApprovalForRevision" {
     try tst.expectError(error.EmptyApprovalForRevision, conf.validateFrontMatter(fm));
 }
 
+// --- Raw HTML divergence (#117): the site renders it, PDFs silently drop it ---
+
+test "raw html: block-level HTML is detected" {
+    const alloc = tst.allocator;
+    const f = (try config.findRawHtml(alloc,
+        "Before.\n\n<div class=\"tab-group\">\n<p>site-only</p>\n</div>\n\nAfter.\n")).?;
+    defer f.deinit(alloc);
+    try tst.expect(f.kind == .block);
+    try tst.expect(std.mem.startsWith(u8, f.snippet, "<div"));
+}
+
+test "raw html: inline HTML is detected" {
+    const alloc = tst.allocator;
+    const f = (try config.findRawHtml(alloc, "Some <span class=\"x\">text</span> here.\n")).?;
+    defer f.deinit(alloc);
+    try tst.expect(f.kind == .in_line);
+}
+
+test "raw html: nested containers are walked (list > quote > inline)" {
+    const alloc = tst.allocator;
+    const f = (try config.findRawHtml(alloc, "- item\n\n  > quoted <br> break\n")).?;
+    defer f.deinit(alloc);
+    try tst.expect(f.kind == .in_line);
+}
+
+test "raw html: code fences, code spans, and autolinks do not trip" {
+    const alloc = tst.allocator;
+    try tst.expect((try config.findRawHtml(alloc, "```html\n<div>not raw</div>\n```\n")) == null);
+    try tst.expect((try config.findRawHtml(alloc, "Use `<div>` for layout.\n")) == null);
+    // Email/URI autolinks parse as .autolink, not inline HTML — the demo
+    // content relies on this (example-security-policy.md uses <security-team@…>).
+    try tst.expect((try config.findRawHtml(alloc, "Contact <security-team@organization.com>.\n")) == null);
+    try tst.expect((try config.findRawHtml(alloc, "See <https://example.com> for details.\n")) == null);
+}
+
+test "review: raw HTML in body → critical; clean body → none" {
+    const alloc = tst.allocator;
+    var tmp = tst.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmpAbsPath(alloc, &tmp);
+    defer alloc.free(tmp_path);
+
+    const html_policy =
+        \\---
+        \\title: "Test Policy"
+        \\description: "Test"
+        \\extra:
+        \\  last_reviewed: "2024-01-01"
+        \\  major_revisions:
+        \\  - date: "2024-01-01"
+        \\    description: "Initial"
+        \\    revised_by: "Author"
+        \\    approved_by: "Approver"
+        \\    version: "1.0"
+        \\---
+        \\Body text.
+        \\
+        \\<div class="note">raw</div>
+        \\
+    ;
+    const clean_policy =
+        \\---
+        \\title: "Test Policy"
+        \\description: "Test"
+        \\extra:
+        \\  last_reviewed: "2024-01-01"
+        \\  major_revisions:
+        \\  - date: "2024-01-01"
+        \\    description: "Initial"
+        \\    revised_by: "Author"
+        \\    approved_by: "Approver"
+        \\    version: "1.0"
+        \\---
+        \\Body text — pure Markdown, no raw HTML.
+        \\
+    ;
+    try tmp.dir.writeFile(io, .{ .sub_path = "html_policy.md", .data = html_policy });
+    try tmp.dir.writeFile(io, .{ .sub_path = "clean_policy.md", .data = clean_policy });
+
+    var conf = try config.load(io, alloc, TestConfig);
+    defer conf.deinit(alloc);
+
+    const html_path = try std.fs.path.join(alloc, &.{ tmp_path, "html_policy.md" });
+    defer alloc.free(html_path);
+    const clean_path = try std.fs.path.join(alloc, &.{ tmp_path, "clean_policy.md" });
+    defer alloc.free(clean_path);
+
+    try tst.expectEqual(config.IssueKind.critical, conf.reviewPolicyFile(io, alloc, html_path));
+    try tst.expectEqual(config.IssueKind.none, conf.reviewPolicyFile(io, alloc, clean_path));
+}
+
+test "review: advisory front matter + raw HTML body → critical (max wins)" {
+    const alloc = tst.allocator;
+    var tmp = tst.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmpAbsPath(alloc, &tmp);
+    defer alloc.free(tmp_path);
+
+    // No top-level `description` (advisory) *and* raw HTML in the body: the
+    // more severe classification must win.
+    const advisory_html =
+        \\---
+        \\title: "Test Policy"
+        \\extra:
+        \\  last_reviewed: "2024-01-01"
+        \\  major_revisions:
+        \\  - date: "2024-01-01"
+        \\    description: "Initial"
+        \\    revised_by: "Author"
+        \\    approved_by: "Approver"
+        \\    version: "1.0"
+        \\---
+        \\Body text.
+        \\
+        \\<span>inline markup</span>
+        \\
+    ;
+    try tmp.dir.writeFile(io, .{ .sub_path = "advisory_html.md", .data = advisory_html });
+
+    var conf = try config.load(io, alloc, TestConfig);
+    defer conf.deinit(alloc);
+
+    const path = try std.fs.path.join(alloc, &.{ tmp_path, "advisory_html.md" });
+    defer alloc.free(path);
+
+    try tst.expectEqual(config.IssueKind.critical, conf.reviewPolicyFile(io, alloc, path));
+}
+
 // --- Draft Mode Adds Watermark ---
 
 test "draft mode: typst source includes draft.png page background" {

--- a/starter/README.md
+++ b/starter/README.md
@@ -51,6 +51,8 @@ extra:
 ---
 ```
 
+Keep policies in pure Markdown - raw HTML is flagged by the build because it would render on the site but vanish from the PDFs. Use a code block to show HTML as an example.
+
 ## Shortcodes
 
 | Shortcode | What it does |

--- a/tests/redaction-leak-check.sh
+++ b/tests/redaction-leak-check.sh
@@ -19,8 +19,10 @@ cd "$(dirname "$0")/.."
 
 fail=0
 tmp_pdfs="$(mktemp -d)"
+tmp_content=""      # populated by the raw-HTML divergence check below
+tmp_html_out=""
 site_out="public"
-trap 'rm -rf "$tmp_pdfs"' EXIT
+trap 'rm -rf "$tmp_pdfs" "$tmp_content" "$tmp_html_out"' EXIT
 
 # Sentinel strings that live inside {% redact() %} blocks in the demo content.
 # Each MUST be absent from every published artifact.
@@ -126,6 +128,62 @@ if command -v pdftotext >/dev/null 2>&1; then
   [ "$fail" -eq 0 ] && echo "  ✓ no sentinels in any redacted PDF"
 else
   echo "▸ pdftotext not available — PDF text layer covered by the Zig golden test."
+fi
+
+echo "▸ Checking raw-HTML divergence pre-flight (#117)…"
+# Raw/inline HTML renders on the Zola site but the Typst/PDF path silently
+# drops it, so the two artifacts would diverge. The build pre-flight must warn
+# by default and fail under --strict. Uses -i to re-root onto a fixture policy
+# dir (policy_dir = "policies/" per config.toml) so the demo content is untouched.
+tmp_content="$(mktemp -d)"
+tmp_html_out="$(mktemp -d)"
+mkdir -p "$tmp_content/policies"
+cat > "$tmp_content/policies/html-divergence-fixture.md" <<'EOF'
+---
+title: "HTML Divergence Fixture"
+description: "Raw HTML that the site would render but PDFs would drop"
+extra:
+  last_reviewed: "2026-01-01"
+  major_revisions:
+    - date: "2026-01-01"
+      description: Initial.
+      revised_by: Test
+      approved_by: Test
+      version: "1.0"
+---
+Before.
+
+<div class="tab-group">site-only markup</div>
+
+After.
+EOF
+
+# Default: warn about the raw HTML but still build (exit 0).
+out="$(./zig-out/bin/policypress -c config.toml -i "$tmp_content" -o "$tmp_html_out" 2>&1)" \
+  || { echo "  ✗ non-strict build failed on the raw-HTML fixture"; fail=1; }
+if grep -q "raw HTML" <<<"$out"; then
+  echo "  ✓ raw HTML warned by default"
+else
+  echo "  ✗ no raw-HTML warning emitted:"; sed 's/^/      /' <<<"$out"; fail=1
+fi
+
+# --strict: must abort with a non-zero exit.
+if ./zig-out/bin/policypress -c config.toml -i "$tmp_content" -o "$tmp_html_out" --strict >/dev/null 2>&1; then
+  echo "  ✗ --strict did not fail on raw HTML"; fail=1
+else
+  echo "  ✓ --strict fails on raw HTML"
+fi
+
+# Regression guard: the real demo content must stay warning-free under --strict
+# (e.g. email autolinks like <security-team@…> must not be misclassified).
+demo_strict=""
+if ! demo_strict="$(./zig-out/bin/policypress -c config.toml -o "$tmp_html_out" --strict 2>&1)"; then
+  echo "  ✗ demo policies failed the --strict build:"; sed 's/^/      /' <<<"$demo_strict"; fail=1
+elif grep -q "raw HTML" <<<"$demo_strict"; then
+  echo "  ✗ demo policies tripped the raw-HTML rule under --strict:"
+  grep "raw HTML" <<<"$demo_strict" | sed 's/^/      /'; fail=1
+else
+  echo "  ✓ demo policies pass --strict (no raw-HTML false positives)"
 fi
 
 if [ "$fail" -ne 0 ]; then


### PR DESCRIPTION
## Summary

Closes the last open item of **#117** — the site/PDF **raw-HTML divergence**.

Raw or inline HTML in a policy body renders on the Zola site (`page.content | safe`) but zigmark's Typst renderer silently drops it (`renderers/typst.zig` omits `html_block`/`html_in_line`, confirmed at `:238`/`:358`). So a policy's website page and its audit PDF could diverge with **no warning** — an integrity problem for an ISMS tool.

Rather than render HTML into PDFs (new attack surface) or strip it from the site, this makes the divergence **loud**: the build pre-flight added in #121 now also checks the body.

## What changed

- **`src/config.zig`** — new `findRawHtml` parses each policy body with zigmark's own parser and walks the AST (`firstRawHtmlInBlocks`/`firstRawHtmlInInlines`) for `html_block`/`html_in_line`. `reviewPolicyFile` now calls `reviewPolicyBody` and classifies raw HTML as **critical** (warn by default, fatal with `--strict`). AST-based, so:
  - `<div>` inside a code fence or `` `<span>` `` inline code does **not** trip;
  - `<user@host>` / `<https://…>` autolinks do **not** trip (they parse as autolinks, which the PDF renders);
  - nested containers (lists, blockquotes, tables) are walked.
- **`src/main.zig`** — wording only (validation is no longer front-matter-only); `--strict` help updated.
- **Tests** — 6 new unit/e2e tests in `src/test.zig`; a build-level section in `tests/redaction-leak-check.sh` asserting warn-by-default, `--strict` failure, and **no false positives on the demo content**.
- **Docs** — README PDF section, `writing-policies` guide, starter README, CHANGELOG.

## Verification

- `zig build test` — **47/47** (was 41).
- `tests/redaction-leak-check.sh` — passes, including the three new raw-HTML checks.
- `zig build e2e` — starter content clean under the new rule (3 policies).
- `./zig-out/bin/policypress -c config.toml -o <tmp> --strict` — exit 0, no raw-HTML warnings on demo content.
- `nix fmt` — 0 files changed.

## Related

- Upstream contract test documenting the intentional drop: sc2in/zigmark#72 (test-only, no release/pin bump).
- No shipped policy contains raw HTML today, so the risk was latent; this prevents it from ever landing silently.

Closes #117.