### PR TITLE
chore(deps): bump zigmark to v0.8.0, pozeiden to v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ versioning; breaking changes to it bump the major version.
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped `zigmark` to v0.8.0 and `pozeiden` to v0.3.0. Both upstream releases
+  were written as production security & quality hardening rounds *for*
+  PolicyPress, and PolicyPress now inherits their input caps and injection
+  hardening: zigmark's 16 MiB / 128-depth parser caps and escaped-SVG-attribute
+  emission, and pozeiden's 4 MiB input / 1000-node / 2000-edge diagram caps and
+  thread-safe internals. No PolicyPress source changes were required; both APIs
+  are additive.
+
 ## [1.4.3] - 2026-07-14
 
 ### Added

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -42,8 +42,8 @@
         // Switch to git+https URLs with hashes before publishing to FlakeHub.
         // .zetta = .{ .path = "../zetta" },
         .zigmark = .{
-            .url = "git+https://github.com/sc2in/zigmark?ref=v0.7.4#b82e5ed2c993e5360c15a3e51732fe76e0712727",
-            .hash = "zigmark-0.7.4-cwOiyEMyCgBy834ZlSIgdMG2lvWRis3kbSrC4pSpkZ1h",
+            .url = "git+https://github.com/sc2in/zigmark?ref=v0.8.0#3bf2c1c9dee118a32f25344710eac4fb97d1bf94",
+            .hash = "zigmark-0.8.0-cwOiyAuwCgAwb2OCEWY8nA3F2tvEssKQiaTDVQMPptuN",
         },
         .tomlz = .{
             .url = "git+https://github.com/sc2in/tomlz.git#ecd64e239768b573ec58286d0db1842991433e99",
@@ -62,8 +62,8 @@
             .hash = "clap-0.11.0-oBajB-jlAQA8x4XSScN1d48Q83iYl-LDU63htNyXbXBe",
         },
         .pozeiden = .{
-            .url = "git+https://github.com/sc2in/pozeiden?ref=v0.2.0#9d44249023a41d4191685023d47a9e2076b99c43",
-            .hash = "pozeiden-0.2.0-NAqiXaypCgBCkAMB3WZpGLPnwV5XTsUvOf3KUY9aAN0p",
+            .url = "git+https://github.com/sc2in/pozeiden?ref=v0.3.0#a29e792fd7b5c8fa9f8d939536552d382c94c871",
+            .hash = "pozeiden-0.3.0-NAqiXXIpCgC2prHxCXJe59cXjbV7f8KcrHb9nstNkhOy",
         },
     },
     .paths = .{

--- a/build.zig.zon2json-lock
+++ b/build.zig.zon2json-lock
@@ -1,8 +1,8 @@
 {
-  "zigmark-0.7.4-cwOiyEMyCgBy834ZlSIgdMG2lvWRis3kbSrC4pSpkZ1h": {
+  "zigmark-0.8.0-cwOiyAuwCgAwb2OCEWY8nA3F2tvEssKQiaTDVQMPptuN": {
     "name": "zigmark",
-    "url": "git+https://github.com/sc2in/zigmark?ref=v0.7.4#b82e5ed2c993e5360c15a3e51732fe76e0712727",
-    "hash": "sha256-/4ABWZ7ioX9+MGWmsLpTPoNTjbNwRyLbjKHbI0JQJz0="
+    "url": "git+https://github.com/sc2in/zigmark?ref=v0.8.0#3bf2c1c9dee118a32f25344710eac4fb97d1bf94",
+    "hash": "sha256-zKLpC3SUaaYAwE1FEDq+cam/ohzR3gAnZ2lNjtsOQZk="
   },
   "tomlz-0.3.0-H2E6w3VKAgCSZQFKG-VugLEn3cjOWshGqwGzAVABNm--": {
     "name": "tomlz",
@@ -63,5 +63,10 @@
     "name": "clap",
     "url": "git+https://github.com/Hejsil/zig-clap#1d3d273524e3c180f015ff1e93c83075e4634e2c",
     "hash": "sha256-Ytdm6tGAO+2V5jNLn7oB0r4DnmhoL6PIDQ0ihxzsLts="
+  },
+  "pozeiden-0.3.0-NAqiXXIpCgC2prHxCXJe59cXjbV7f8KcrHb9nstNkhOy": {
+    "name": "pozeiden",
+    "url": "git+https://github.com/sc2in/pozeiden?ref=v0.3.0#a29e792fd7b5c8fa9f8d939536552d382c94c871",
+    "hash": "sha256-e84o2po+IH2matp/iAhJBjtGOtqBmLPDsbiRggwWg0c="
   }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -532,11 +532,16 @@
             };
 
             devShells.default = pkgs.mkShell {
+              # Note: the `policypress` package is deliberately NOT a devShell
+              # input. Building it requires a valid build.zig.zon2json-lock, but
+              # the shellHook below regenerates that lock on entry — so depending
+              # on the package here would deadlock the shell whenever a dep bump
+              # leaves the lock stale (the sandbox has no network to fetch the
+              # new dep). Develop with `zig build` / `nix run .#` instead.
               buildInputs =
                 runtimeDeps
                 ++ config.pre-commit.settings.enabledPackages
                 ++ [
-                  policypress
                   zig
                   pkgs.act
                   pkgs.omnix


### PR DESCRIPTION
## Summary

Moves the two breakout deps to their latest releases. Both upstream releases were written as production security & quality hardening rounds **for** PolicyPress; none of that protection reaches PolicyPress until the pins move. This is the P0 of the launch batch (#120).

- **zigmark → v0.8.0**: 16 MiB / 128-depth parser caps, escaped SVG attributes, thread-safe internals, `#raw()` code emission.
- **pozeiden → v0.3.0**: 4 MiB input / 1000-node / 2000-edge diagram caps.

**No PolicyPress source changes required** — both APIs are additive (`AST.Block`/`AST.Inline` unchanged, so the exhaustive raw-HTML switches in `config.zig` still hold). Regenerated `build.zig.zon2json-lock`. zigmark's lazy `pozeiden` v0.2.0 transitive pin remains in the lock — cosmetic; it is compiled only into zigmark's own exe/WASM, never into PolicyPress.

Also drops the `policypress` package from its own devShell inputs: building it needs a valid `zon2json-lock`, but the shellHook regenerates that lock on entry, so depending on the package deadlocked `nix develop` whenever a dep bump left the lock stale (the build sandbox has no network to fetch the new, still-unlocked dep). Develop with `zig build` / `nix run .#` instead.

## Verification

- `zig build check && zig build && zig build test && zig build e2e` ✅
- `nix build .#policypress-safe` ✅
- `nix flake check` ✅ (treefmt, tests, pre-commit)

Part of the launch-gate batch (#119/#120).