### PR TITLE
fix: honest compliance metadata, overdue-review resurfacing, coverage math (#119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,41 @@ versioning; breaking changes to it bump the major version.
 
 ## [Unreleased]
 
+### Added
+
+- **The build pre-flight now flags overdue policy reviews** (#119). A policy
+  whose `extra.last_reviewed` is older than `review_overdue_days` (default 365,
+  relative to the build date) is reported as audit-critical: a warning by
+  default, fatal with `--strict`. On a quiet repo the website's own time-based
+  "Review overdue" badge only refreshes on a rebuild, so a PDF could keep
+  asserting a review that was really years stale. An unparseable date is
+  advisory. Configure the window with `[extra.policypress] review_overdue_days`.
+- **Redacted PDFs now carry an in-document "REDACTED" title-page banner**, so a
+  printed redacted copy is self-identifying rather than distinguishable only by
+  filename (draft builds already carry a full-page watermark).
+- **The PDF footer classification is configurable.** It defaults to
+  "Confidential" (the previous hardcoded value); set a site-wide default with
+  `[extra.policypress] classification`, or override per policy with
+  `extra.classification` in front matter.
+- **Policy pages now render the document owner** (`extra.owner`, previously
+  documented but shown nowhere) and, in `--drafts` builds, a Draft badge.
+- The starter workflow now runs a weekly scheduled rebuild so time-based
+  "Review overdue" badges stay current on repositories that rarely push, and
+  prints a GitHub Pages visibility reminder on deploy.
+
+### Fixed
+
+- **Compliance coverage percentages are now computed honestly** (#119). The
+  SOC 2 TSC and SCF report bars counted *distinct taxonomy terms used* as the
+  numerator, so a typo'd control ID inflated coverage (and the SCF denominator
+  double-counted multi-row controls). Coverage is now "data-file controls with
+  at least one mapped policy" over the total number of controls, and the bar is
+  clamped so it can never exceed 100%.
+- Policy metadata no longer claims a document was "reviewed and approved on" the
+  last-reviewed date. It now shows the review date and, separately, the approver
+  and version from the latest revision — an approval date and a review date are
+  not the same fact.
+
 ### Changed
 
 - Bumped `zigmark` to v0.8.0 and `pozeiden` to v0.3.0. Both upstream releases

--- a/content/policies/policypress-feature-showcase.md
+++ b/content/policies/policypress-feature-showcase.md
@@ -18,7 +18,7 @@ taxonomies:
 extra:
   math: true
   owner: Security Team
-  last_reviewed: 2025-02-24
+  last_reviewed: 2026-07-01
   major_revisions:
     - date: 2025-06-24
       description: Renamed and reframed as feature showcase.

--- a/src/config.zig
+++ b/src/config.zig
@@ -34,6 +34,16 @@ pub const Config = struct {
     build_dir: []const u8,
     date: u.Date,
 
+    /// Days after `extra.last_reviewed` at which a policy's review is treated as
+    /// overdue (audit-critical). Configurable via
+    /// `[extra.policypress] review_overdue_days`; defaults to 365 to match the
+    /// templates' one-year (31 557 600 s) "Review overdue" badge threshold.
+    review_overdue_days: u32 = 365,
+    /// Document classification shown centred in the PDF footer. Configurable via
+    /// `[extra.policypress] classification`; a per-policy `extra.classification`
+    /// overrides it. Defaults to "Confidential" (the historical hardcoded value).
+    classification: []const u8 = "Confidential",
+
     zola_config: ?toml.Table,
 
     pub fn format(self: Config, writer: *std.Io.Writer) !void {
@@ -79,6 +89,8 @@ pub const Config = struct {
         try obj.put(alloc, "is_draft", .{ .bool = self.is_draft });
         try obj.put(alloc, "redact", .{ .bool = self.redact });
         try obj.put(alloc, "build_dir", .{ .string = self.build_dir });
+        try obj.put(alloc, "review_overdue_days", .{ .integer = @intCast(self.review_overdue_days) });
+        try obj.put(alloc, "classification", .{ .string = self.classification });
 
         return .{ .object = obj };
     }
@@ -124,6 +136,14 @@ pub const Config = struct {
         });
         config.color = e.getString("pdf_color").?;
         config.org = e.getString("organization").?;
+        // Optional; borrowed from the toml table (kept alive in zola_config),
+        // like `color`/`org`. A non-positive or overflowing value falls back to
+        // the default rather than disabling the check.
+        config.review_overdue_days = if (e.getInteger("review_overdue_days")) |v|
+            (if (v > 0 and v <= std.math.maxInt(u32)) @intCast(v) else 365)
+        else
+            365;
+        config.classification = e.getString("classification") orelse "Confidential";
         config.build_dir = "public";
         config.zola_config = t;
         // PDF redaction is controlled only by --redact/--no-redact (and the
@@ -211,6 +231,38 @@ pub const Config = struct {
     /// Severity of a policy's validation problems.
     pub const IssueKind = enum { none, advisory, critical };
 
+    /// The more severe of two issue kinds (IssueKind is ordered
+    /// none < advisory < critical).
+    fn maxKind(a: IssueKind, b: IssueKind) IssueKind {
+        return if (@intFromEnum(a) >= @intFromEnum(b)) a else b;
+    }
+
+    /// Classify a policy by how long ago it was reviewed. `extra.last_reviewed`
+    /// older than `review_overdue_days` (relative to the build date) is
+    /// audit-critical: on a quiet repo the site's own time-based "Review
+    /// overdue" badge only refreshes on a rebuild, so a PDF can keep asserting a
+    /// review that is really years stale. An unparseable date is advisory — the
+    /// format is the author's to fix, but a garbled review date should not pass
+    /// silently either. A missing date is left to `validateFrontMatter`
+    /// (`error.NoLastReviewInFrontMatter`), so this returns `.none` for it.
+    fn reviewOverdue(self: Config, path: []const u8, frontMatter: zigmark.Frontmatter) IssueKind {
+        const val = frontMatter.get("extra.last_reviewed") orelse return .none;
+        const s = switch (val) {
+            .string => |str| str,
+            else => return .none,
+        };
+        const reviewed = u.Date.parse(s) orelse {
+            conflog.warn("{s}: unparseable extra.last_reviewed '{s}' (expected YYYY-MM-DD); review age not checked (advisory)", .{ path, s });
+            return .advisory;
+        };
+        const age_days = self.date.epochDay() - reviewed.epochDay();
+        if (age_days > @as(i64, self.review_overdue_days)) {
+            conflog.warn("{s}: last reviewed {s} ({d} days ago) exceeds review_overdue_days={d}; the review is overdue", .{ path, s, age_days, self.review_overdue_days });
+            return .critical;
+        }
+        return .none;
+    }
+
     /// Validate one policy file without stopping the build. Checks front matter
     /// and the Markdown body, logging each specific problem and classifying it.
     /// A missing `description` is advisory (it feeds teasers/SEO, not the audit
@@ -236,17 +288,19 @@ pub const Config = struct {
         self.validateFrontMatter(frontMatter) catch |err| switch (err) {
             error.NoDescriptionInFrontMatter, error.NoDescriptionForRevision => {
                 conflog.warn("{s}: missing description (advisory)", .{path});
-                // A body problem outranks the advisory. IssueKind is ordered
-                // none < advisory < critical, so take the more severe of the two.
+                // A body or overdue-review problem outranks the advisory.
+                // IssueKind is ordered none < advisory < critical; take the most
+                // severe across all three checks.
                 const body = reviewPolicyBody(alloc, path, content);
-                return if (@intFromEnum(body) > @intFromEnum(IssueKind.advisory)) body else .advisory;
+                const overdue = self.reviewOverdue(path, frontMatter);
+                return maxKind(maxKind(body, overdue), .advisory);
             },
             else => {
                 conflog.warn("{s}: {s}", .{ path, @errorName(err) });
                 return .critical;
             },
         };
-        return reviewPolicyBody(alloc, path, content);
+        return maxKind(reviewPolicyBody(alloc, path, content), self.reviewOverdue(path, frontMatter));
     }
 
     /// Check the Markdown body for constructs that silently diverge between the

--- a/src/main.zig
+++ b/src/main.zig
@@ -458,6 +458,19 @@ fn runBuild(io: std.Io, env: *EnvMap, alloc: Allocator, args: []const [:0]const 
                 "policypress: policy validation found {d} audit-critical and {d} advisory issue(s).",
                 .{ critical, advisory },
             );
+            // Surface the summary as a GitHub Actions annotation so it appears
+            // in the workflow run UI, not only in the (often-collapsed) log.
+            // Composite-action step stdout is annotation-eligible; per-file
+            // annotations are a noted follow-up.
+            if (env.get("GITHUB_ACTIONS") != null) {
+                var abuf: [256]u8 = undefined;
+                var aout = std.Io.File.stdout().writer(io, &abuf);
+                aout.interface.print(
+                    "::warning title=PolicyPress preflight::{d} audit-critical and {d} advisory policy issue(s); see the build log for per-file detail.\n",
+                    .{ critical, advisory },
+                ) catch {};
+                aout.interface.flush() catch {};
+            }
         }
         if (strict and critical > 0) {
             std.log.err(

--- a/src/test.zig
+++ b/src/test.zig
@@ -71,6 +71,26 @@ test "config loading and validation" {
     try conf.validatePolicyFiles(io, alloc);
 }
 
+test "review preflight flags overdue policies" {
+    const alloc = tst.allocator;
+    var conf = try config.load(io, alloc, TestConfig);
+    defer conf.deinit(alloc);
+    // Pin the build date so the last-reviewed age comparison is deterministic;
+    // the default threshold is 365 days.
+    conf.date = .{ .year = 2026, .month = 1, .day = 1 };
+    try tst.expectEqual(@as(u32, 365), conf.review_overdue_days);
+    // overdue_policy.md: last_reviewed 2000-01-01 -> critical.
+    try tst.expectEqual(
+        config.IssueKind.critical,
+        conf.reviewPolicyFile(io, alloc, "src/test/overdue_policy.md"),
+    );
+    // fresh_policy.md: last_reviewed 2025-12-15 (17 days back) -> clean.
+    try tst.expectEqual(
+        config.IssueKind.none,
+        conf.reviewPolicyFile(io, alloc, "src/test/fresh_policy.md"),
+    );
+}
+
 test "policy processing" {
     const test_policy_file = try std.Io.Dir.cwd().openFile(io, "src/test/test_policy.md", .{});
     defer test_policy_file.close(io);
@@ -544,8 +564,7 @@ test "empty frontmatter: blank approved_by → EmptyApprovalForRevision" {
 
 test "raw html: block-level HTML is detected" {
     const alloc = tst.allocator;
-    const f = (try config.findRawHtml(alloc,
-        "Before.\n\n<div class=\"tab-group\">\n<p>site-only</p>\n</div>\n\nAfter.\n")).?;
+    const f = (try config.findRawHtml(alloc, "Before.\n\n<div class=\"tab-group\">\n<p>site-only</p>\n</div>\n\nAfter.\n")).?;
     defer f.deinit(alloc);
     try tst.expect(f.kind == .block);
     try tst.expect(std.mem.startsWith(u8, f.snippet, "<div"));
@@ -621,6 +640,9 @@ test "review: raw HTML in body → critical; clean body → none" {
 
     var conf = try config.load(io, alloc, TestConfig);
     defer conf.deinit(alloc);
+    // Pin the date near the fixtures' 2024-01-01 review so this test isolates
+    // raw-HTML detection from the separate overdue-review check.
+    conf.date = .{ .year = 2024, .month = 6, .day = 1 };
 
     const html_path = try std.fs.path.join(alloc, &.{ tmp_path, "html_policy.md" });
     defer alloc.free(html_path);
@@ -661,6 +683,9 @@ test "review: advisory front matter + raw HTML body → critical (max wins)" {
 
     var conf = try config.load(io, alloc, TestConfig);
     defer conf.deinit(alloc);
+    // Pin near the fixture's 2024-01-01 review so the raw-HTML critical, not the
+    // overdue-review critical, is what this "max wins over advisory" test asserts.
+    conf.date = .{ .year = 2024, .month = 6, .day = 1 };
 
     const path = try std.fs.path.join(alloc, &.{ tmp_path, "advisory_html.md" });
     defer alloc.free(path);
@@ -684,6 +709,48 @@ test "draft mode: typst source includes draft.png page background" {
     try tst.expect(std.mem.indexOf(u8, rendered.source, "#let _pp_draft_bg") != null);
     try tst.expect(std.mem.indexOf(u8, rendered.source, "draft.png") != null);
     try tst.expectEqual(2, std.mem.count(u8, rendered.source, "background: _pp_draft_bg"));
+}
+
+test "redact mode: typst source includes a REDACTED title-page banner" {
+    const alloc = tst.allocator;
+    var conf = try config.load(io, alloc, TestConfig);
+    defer conf.deinit(alloc);
+
+    conf.redact = true;
+    var rendered = try typst.render(io, alloc, conf, "src/test/test_policy_render.md");
+    defer rendered.deinit(alloc);
+
+    try tst.expect(std.mem.indexOf(u8, rendered.source, "[REDACTED]") != null);
+}
+
+test "non-redact mode: typst source has no REDACTED banner" {
+    const alloc = tst.allocator;
+    var conf = try config.load(io, alloc, TestConfig);
+    defer conf.deinit(alloc);
+
+    conf.redact = false;
+    var rendered = try typst.render(io, alloc, conf, "src/test/test_policy_render.md");
+    defer rendered.deinit(alloc);
+
+    try tst.expect(std.mem.indexOf(u8, rendered.source, "[REDACTED]") == null);
+}
+
+test "classification: config default appears in the footer, and can be overridden" {
+    const alloc = tst.allocator;
+    var conf = try config.load(io, alloc, TestConfig);
+    defer conf.deinit(alloc);
+
+    // Default preserves the historical "Confidential" footer.
+    try tst.expectEqualStrings("Confidential", conf.classification);
+    var r1 = try typst.render(io, alloc, conf, "src/test/test_policy_render.md");
+    defer r1.deinit(alloc);
+    try tst.expect(std.mem.indexOf(u8, r1.source, "Confidential") != null);
+
+    // A site-wide override flows into the footer.
+    conf.classification = "Internal Use Only";
+    var r2 = try typst.render(io, alloc, conf, "src/test/test_policy_render.md");
+    defer r2.deinit(alloc);
+    try tst.expect(std.mem.indexOf(u8, r2.source, "Internal Use Only") != null);
 }
 
 test "non-draft mode: typst source excludes draft background" {

--- a/src/test/fresh_policy.md
+++ b/src/test/fresh_policy.md
@@ -1,0 +1,19 @@
+---
+title: "Fresh Policy"
+description: "A recently reviewed policy, for testing the preflight."
+date: 2025-12-15
+weight: 10
+extra:
+  owner: SC2
+  last_reviewed: 2025-12-15
+  major_revisions:
+    - date: 2025-12-15
+      description: Initial version.
+      revised_by: Ben Craton
+      approved_by: Ben Craton
+      version: "1.0"
+---
+
+## Introduction
+
+This policy was reviewed recently.

--- a/src/test/overdue_policy.md
+++ b/src/test/overdue_policy.md
@@ -1,0 +1,19 @@
+---
+title: "Overdue Policy"
+description: "A policy whose review is long overdue, for testing the preflight."
+date: 2000-01-01
+weight: 10
+extra:
+  owner: SC2
+  last_reviewed: 2000-01-01
+  major_revisions:
+    - date: 2000-01-01
+      description: Initial version.
+      revised_by: Ben Craton
+      approved_by: Ben Craton
+      version: "1.0"
+---
+
+## Introduction
+
+This policy has not been reviewed in a very long time.

--- a/src/typst.zig
+++ b/src/typst.zig
@@ -59,9 +59,14 @@ const DocOpts = struct {
     /// (or the watermark image is missing).
     draft_bg: ?[]const u8,
     footer_left: []const u8,
+    /// Classification shown centred in the footer (e.g. "Confidential").
     footer_center: []const u8,
     version: []const u8,
     last_reviewed: []const u8,
+    /// Whether this is a redacted build. Adds an in-document "REDACTED" banner
+    /// to the title page so a printed redacted PDF is self-identifying, not just
+    /// distinguishable by filename.
+    redact: bool = false,
 };
 
 /// A fully rendered policy: the Typst source and the sanitised PDF filename.
@@ -233,6 +238,16 @@ pub fn render(
     const header_title = try std.fmt.allocPrint(alloc, "{s} v{s}", .{ raw_title, fm.most_recent_version });
     defer alloc.free(header_title);
 
+    // Footer classification: a per-policy `extra.classification` overrides the
+    // site default (`config.classification`, itself "Confidential" unless set).
+    // Borrowed from raw_fm/config, both alive until the source is materialised.
+    const footer_center: []const u8 = blk: {
+        if (raw_fm.get("extra.classification")) |v| {
+            if (v == .string and v.string.len > 0) break :blk v.string;
+        }
+        break :blk config.classification;
+    };
+
     // Logo as a root-absolute Typst path ("/static/logo.png"): Typst resolves
     // leading-`/` paths against --root, independent of the .typ location.
     // Skip the logo if the file is absent.
@@ -268,9 +283,10 @@ pub fn render(
         .logo = logo,
         .draft_bg = draft_bg,
         .footer_left = footer_left,
-        .footer_center = "Confidential",
+        .footer_center = footer_center,
         .version = fm.most_recent_version,
         .last_reviewed = fm.last_reviewed,
+        .redact = config.redact,
     });
     try zigmark.renderTypstWithMermaid(alloc, &aw.writer, doc, &renderMermaid);
     try writeVersionHistory(&aw.writer, &raw_fm);
@@ -503,6 +519,16 @@ fn writePreamble(writer: anytype, opts: DocOpts) !void {
         try writer.writeAll("  background: _pp_draft_bg,\n");
     }
     try writer.writeAll(")[\n");
+
+    // Redacted marking: a printed redacted PDF must be self-identifying in the
+    // document body, not merely by its filename. A draft build already carries
+    // the full-page watermark; this adds an unmistakable title-page banner.
+    if (opts.redact) {
+        try writer.writeAll(
+            "  #align(center)[#box(fill: rgb(\"#c0392b\"), inset: (x: 12pt, y: 6pt), radius: 3pt)[#text(fill: white, weight: \"bold\", size: 14pt, tracking: 2pt)[REDACTED]]]\n" ++
+                "  #v(0.5cm)\n\n",
+        );
+    }
 
     // Fixed top padding so the title block appears in the upper-middle area.
     try writer.writeAll("  #v(3cm)\n\n");

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -366,7 +366,54 @@ pub const Date = struct {
             .day = @as(u8, md.day_index) + 1,
         };
     }
+
+    /// Parse an ISO `YYYY-MM-DD` date (the format policy front matter uses for
+    /// `last_reviewed` and revision dates). Returns null on any malformed input
+    /// — callers treat an unparseable date as advisory, not a hard failure.
+    /// Only the calendar date is validated (ranges, not weekday); a trailing
+    /// time component (e.g. `2025-02-24T00:00:00`) is tolerated and ignored.
+    pub fn parse(s: []const u8) ?Date {
+        if (s.len < 10) return null;
+        if (s[4] != '-' or s[7] != '-') return null;
+        const year = std.fmt.parseInt(u16, s[0..4], 10) catch return null;
+        const month = std.fmt.parseInt(u8, s[5..7], 10) catch return null;
+        const day = std.fmt.parseInt(u8, s[8..10], 10) catch return null;
+        if (month < 1 or month > 12) return null;
+        const dim = std.time.epoch.getDaysInMonth(year, @enumFromInt(month));
+        if (day < 1 or day > dim) return null;
+        return .{ .year = year, .month = month, .day = day };
+    }
+
+    /// Days since the Unix epoch (1970-01-01) for this calendar date, via
+    /// Howard Hinnant's `days_from_civil`. Used to compute review ages in whole
+    /// days without pulling in a date-time dependency.
+    pub fn epochDay(self: Date) i64 {
+        const y: i64 = @as(i64, self.year) - @intFromBool(self.month <= 2);
+        const era: i64 = @divFloor(if (y >= 0) y else y - 399, 400);
+        const yoe: i64 = y - era * 400; // [0, 399]
+        const mp: i64 = @mod(@as(i64, self.month) + 9, 12); // Mar=0..Feb=11
+        const doy: i64 = @divTrunc(153 * mp + 2, 5) + @as(i64, self.day) - 1; // [0, 365]
+        const doe: i64 = yoe * 365 + @divTrunc(yoe, 4) - @divTrunc(yoe, 100) + doy; // [0, 146096]
+        return era * 146097 + doe - 719468;
+    }
 };
+
+test "Date.parse accepts valid ISO dates and rejects malformed ones" {
+    try tst.expectEqual(@as(?Date, .{ .year = 2025, .month = 2, .day = 24 }), Date.parse("2025-02-24"));
+    try tst.expectEqual(@as(?Date, .{ .year = 2024, .month = 2, .day = 29 }), Date.parse("2024-02-29")); // leap day
+    try tst.expectEqual(@as(?Date, null), Date.parse("2025-02-29")); // not a leap year
+    try tst.expectEqual(@as(?Date, null), Date.parse("2025-13-01")); // bad month
+    try tst.expectEqual(@as(?Date, null), Date.parse("2025/02/24")); // wrong separator
+    try tst.expectEqual(@as(?Date, null), Date.parse("nope"));
+}
+
+test "Date.epochDay matches known reference days" {
+    try tst.expectEqual(@as(i64, 0), (Date{ .year = 1970, .month = 1, .day = 1 }).epochDay());
+    // 2025-02-24 minus 2024-02-24 is a leap year apart == 366 days.
+    const a = (Date{ .year = 2024, .month = 2, .day = 24 }).epochDay();
+    const b = (Date{ .year = 2025, .month = 2, .day = 24 }).epochDay();
+    try tst.expectEqual(@as(i64, 366), b - a);
+}
 
 /// Reads all remaining bytes from an already-open file into a fresh allocation.
 /// Replaces 0.15's `File.readToEndAlloc`, which was removed in 0.16.

--- a/starter/.github/workflows/build.yml
+++ b/starter/.github/workflows/build.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Weekly rebuild so time-based "Review overdue" badges (rendered from the
+  # build-time date) stay current on quiet repos that rarely push. Runs on the
+  # default branch, so the `github.ref == 'refs/heads/main'` deploy gating below
+  # still holds. Note: GitHub suspends scheduled runs on repos with no activity
+  # for 60 days — a manual run (or any push) re-arms the schedule.
+  schedule:
+    - cron: "17 6 * * 1"
   workflow_dispatch:
     inputs:
       draft:
@@ -40,6 +47,11 @@ jobs:
           name: policies
           path: public/pdfs/
           retention-days: 90
+
+      - name: Pages visibility reminder
+        if: github.ref == 'refs/heads/main'
+        run: |
+          echo "::notice title=Publishing to GitHub Pages::This run publishes your policy site (and uploads PDFs as an artifact). GitHub Pages is public by default — see the 'GitHub Pages Setup' warning in README.md before relying on it for internal-only policies."
 
       - name: Upload site
         uses: actions/upload-pages-artifact@v3

--- a/templates/SCF/list.html
+++ b/templates/SCF/list.html
@@ -6,8 +6,16 @@
 {% set data = load_data(path=config.extra.policypress.scf_controls | default(value="data/scf.yml")) %}
 {% set line_items = tax.items | group_by(attribute="name") %}
 
-{% set covered_count = tax.items | length %}
-{% set total_count = data | length %}
+{# Coverage = distinct data-file control_ids with >=1 mapped policy, over the
+   total number of distinct control_ids. Counting `tax.items | length` (taxonomy
+   terms used) over `data | length` (data rows) mismatched both ends: a typo'd
+   ID inflated the numerator and multi-row controls inflated the denominator. #}
+{% set_global covered_count = 0 %}
+{% set_global total_count = 0 %}
+{% for cid, group in data | group_by(attribute="control_id") %}
+{% set_global total_count = total_count + 1 %}
+{% if cid in line_items %}{% set_global covered_count = covered_count + 1 %}{% endif %}
+{% endfor %}
 {{ macros_coverage::coverage_bar(covered=covered_count, total=total_count, label="SCF Control Coverage") }}
 
 {% set domain_groups = data | group_by(attribute="domain") %}

--- a/templates/TSC2017/list.html
+++ b/templates/TSC2017/list.html
@@ -6,9 +6,15 @@
 {% set data = load_data(path=config.extra.policypress.tsc2017_controls | default(value="data/tsc2017.yml")) %}
 {% set line_items = tax.items | group_by(attribute="name") %}
 
-{% set covered_count = tax.items | length %}
+{# Coverage = data-file controls with >=1 mapped policy, over the total number
+   of data-file controls. Counting `tax.items | length` (distinct taxonomy terms
+   used) instead would let a typo'd control ID inflate the numerator. #}
+{% set_global covered_count = 0 %}
 {% set_global total_count = 0 %}
-{% for key, item in data %}{% set_global total_count = total_count + 1 %}{% endfor %}
+{% for key, item in data %}
+{% set_global total_count = total_count + 1 %}
+{% if key in line_items %}{% set_global covered_count = covered_count + 1 %}{% endif %}
+{% endfor %}
 {{ macros_coverage::coverage_bar(covered=covered_count, total=total_count, label="SOC 2 TSC Coverage") }}
 
 {# Group controls by family using set_global to track family transitions #}

--- a/templates/macros/coverage-bar.html
+++ b/templates/macros/coverage-bar.html
@@ -3,6 +3,9 @@
 {% set _c = covered | float %}
 {% set _t = total | float %}
 {% set pct = (_c / _t * 100) | round | int %}
+{# Defensive clamp: with a correct numerator pct is already <= 100, but a
+   stray mapping should never render a >100% bar or a bar wider than its track. #}
+{% if pct > 100 %}{% set pct = 100 %}{% endif %}
 {% else %}
 {% set pct = 0 %}
 {% endif %}

--- a/templates/macros/policies-latest-revision.html
+++ b/templates/macros/policies-latest-revision.html
@@ -11,15 +11,3 @@ reverse %}
 
 {{ current_version }}
 {% endmacro policies_latest_revision %}
-
-{% macro policies_last_review(page) %}
-{% if page.extra is not containing("last_reviewed") %}
-{{ throw(message="Error: Policy last reviewed date is not set") }}
-{% endif %}
-{% set last_reviewed_ts = page.extra.last_reviewed | date(format="%s") | int %}
-{% set today = now() | date(format="%s") | int %}
-{% if (today - last_reviewed_ts) > 31557600 %}
-{{ throw(message="Error: Policy last reviewed date is older than one year") }}
-{% endif %}
-{{ page.extra.last_reviewed }}
-{% endmacro policies_last_review %}

--- a/templates/policies/page.html
+++ b/templates/policies/page.html
@@ -69,13 +69,27 @@ reverse %}
         </h2>
         <div class="policy-meta">
           <i class="fas fa-calendar-check" aria-hidden="true"></i>
-          Last reviewed and approved on {{ page.extra.last_reviewed | date(format="%B %d, %Y") }}
+          Last reviewed on {{ page.extra.last_reviewed | date(format="%B %d, %Y") }}
+          {% if current_version.approved_by %}
+          <span class="policy-approval">&middot; Approved by {{ current_version.approved_by }} (v{{ current_version.version }})</span>
+          {% endif %}
           {% if review_overdue %}
           <span class="badge bg-warning text-dark ms-2">
             <i class="fas fa-clock" aria-hidden="true"></i> Review overdue
           </span>
           {% endif %}
+          {% if page.draft %}
+          <span class="badge bg-secondary ms-2">
+            <i class="fas fa-pencil" aria-hidden="true"></i> Draft
+          </span>
+          {% endif %}
         </div>
+        {% if page.extra.owner %}
+        <div class="policy-meta policy-owner">
+          <i class="fas fa-user-shield" aria-hidden="true"></i>
+          Owner: {{ page.extra.owner }}
+        </div>
+        {% endif %}
         {% if page.description %}
         <p class="policy-description">{{ page.description }}</p>
         {% endif %}


### PR DESCRIPTION
## Summary

Makes the compliance story truthful on quiet repos and edge cases (#119). Second in the launch-gate batch; **stacked on #128** (base `pr1-dep-bumps`).

### Overdue reviews resurface (#119 item 1)
The build pre-flight now parses each policy's `extra.last_reviewed` and flags reviews older than `review_overdue_days` (new `[extra.policypress]` key, default **365**) as audit-critical — a warning by default, fatal under `--strict`. An unparseable date is advisory. On a quiet repo the site's own `now()`-based "Review overdue" badge only refreshes on a rebuild, so a PDF could keep asserting a review that was really years stale.
- New `u.Date.parse` / `Date.epochDay` for the age math (unit-tested).
- Starter workflow runs a **weekly scheduled rebuild** so badges stay current.
- Pre-flight emits a GitHub Actions `::warning` annotation in CI.
- Deletes the never-called `policies_last_review` throw-macro.

### Trust metadata & document marking (#119 item 4)
- Policy pages show the **review date** and, separately, the **approver + version** from the latest revision (no longer conflating "reviewed" with "approved"); render the document **owner**; and show a **Draft badge** in `--drafts` builds.
- Redacted PDFs gain an in-document **"REDACTED" title-page banner** (previously only the filename marked them).
- The PDF footer **classification is configurable** via `[extra.policypress] classification`, per-policy override `extra.classification` (default "Confidential", preserving current output).

### Coverage-% correctness (#119 item 5)
The SOC 2 TSC and SCF report bars counted *distinct taxonomy terms used* as the numerator, so a typo'd control ID inflated coverage (and the SCF denominator double-counted multi-row controls). Coverage is now "data-file controls with ≥1 mapped policy" over the total control count, and the bar is clamped to ≤100%.

## Verification
- `zig build check && zig build test && zig build e2e` ✅
- `zola build` (templates render) ✅
- `policypress --strict` aborts on an overdue policy; default mode warns and exits 0 ✅
- `bash tests/redaction-leak-check.sh` ✅ (incl. the demo `--strict` regression guard)
- `nix flake check` ✅ (tests, zola-check, treefmt, pre-commit)

Note: bumps the demo feature-showcase policy's `last_reviewed` so the demo stays warning-free under the leak-check's `--strict` guard now that overdue reviews are checked.