### PR TITLE
docs: document the release flow under branch protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ versioning; breaking changes to it bump the major version.
   third-party GitHub Actions to commit SHAs; GitHub-owned `actions/*` stay
   tag-pinned.
 
+### Documentation
+
+- Documented the release flow under branch protection. `main`'s rulesets require
+  a PR and passing status checks with no bypass, so a release commit can no
+  longer be pushed straight to `main`. `nix run .#bump` now prints the
+  branch → PR → merge → tag steps (and warns when run on `main`) instead of the
+  old `git push origin HEAD` one-liner, and `CONTRIBUTING.md` gained a
+  "Releasing" section describing the same flow.
+
 ### Added
 
 - **Opt-in tagged, accessible PDFs (PDF/UA-1)** (#119). Set

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,3 +52,17 @@ zola build   # verify template/theme changes render correctly
 ## Release notes
 
 Follow `CHANGELOG.md` conventions; record notable changes at the corresponding version section. A maintainer may adapt as needed.
+
+## Releasing
+
+`main` is protected by repository rulesets (`.github/rulesets/`): it requires a pull request, a linear history, GPG-signed commits, and passing status checks (`ci (ubuntu-latest)` + `ci (macos-latest)`). The `required_status_checks` rule has an empty bypass list, so **nobody can push a release commit straight to `main`** — not even an org/repo admin. Releases go through a PR like everything else:
+
+1. On a branch (not `main`), run `nix run .#bump -- <patch|minor|major>`. This updates `build.zig.zon`, `config.toml`, and rolls `CHANGELOG.md`'s `[Unreleased]` section into a versioned one, then makes a `chore: release X.Y.Z` commit.
+2. Push the branch, open a PR, and let CI go green. Merge with **squash** or **rebase** (merge commits are disallowed by `required_linear_history`).
+3. Tag the merged commit on `main` and push the tag:
+   ```
+   git switch main && git pull
+   git tag vX.Y.Z && git push origin vX.Y.Z
+   ```
+
+The tag push (not the merge) triggers the release workflow: CI builds the binaries, cuts the GitHub release, and publishes to FlakeHub. Rulesets target branches only, so the tag push itself isn't gated — just make sure the tag points at the merged commit on `main`.

--- a/flake.nix
+++ b/flake.nix
@@ -628,20 +628,37 @@
 
                     echo "Updated build.zig.zon, config.toml, CHANGELOG.md"
 
+                    branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
                     if [ "$commit" = 1 ]; then
                       git add build.zig.zon config.toml CHANGELOG.md
                       git commit -m "chore: release $new"
                       echo ""
-                      echo "Committed 'chore: release $new'. Publish with:"
-                      echo "  git tag v$new && git push origin HEAD v$new"
+                      echo "Committed 'chore: release $new' on '$branch'."
                     else
                       echo ""
-                      echo "Files edited (not committed). Then:"
+                      echo "Files edited (not committed). Commit with:"
                       echo "  git add build.zig.zon config.toml CHANGELOG.md && git commit -m 'chore: release $new'"
-                      echo "  git tag v$new && git push origin HEAD v$new"
                     fi
+
                     echo ""
-                    echo "On tag push, CI builds binaries, cuts the GitHub release, and publishes to FlakeHub."
+                    echo "Releasing (main is protected: direct pushes are rejected — a PR + green CI is required):"
+                    if [ "$branch" = "main" ]; then
+                      echo "  ! You are on 'main'. Move the release work onto a branch first:"
+                      echo "      git switch -c release-$new"
+                      if [ "$commit" = 1 ]; then
+                        echo "      git branch --force main origin/main   # rewind local main back to origin"
+                      fi
+                      echo ""
+                    fi
+                    echo "  1. Push the release branch and open a PR:"
+                    echo "       git push -u origin release-$new"
+                    echo "  2. Wait for ci (ubuntu-latest) + ci (macos-latest) to pass, then squash- or rebase-merge."
+                    echo "  3. Tag the merged commit on main and push the tag:"
+                    echo "       git switch main && git pull"
+                    echo "       git tag v$new && git push origin v$new"
+                    echo ""
+                    echo "The tag push triggers CI to build binaries, cut the GitHub release, and publish to FlakeHub."
                   '';
                 };
               in


### PR DESCRIPTION
## Why

`main` is protected by the repository rulesets (`.github/rulesets/`): a PR is required, and `protect-main` enforces `required_status_checks` (`ci (ubuntu-latest)` + `ci (macos-latest)`) with an **empty bypass list**. That means a fresh release commit can no longer be pushed straight to `main` — not even by an admin — because the required checks can't have run on a commit that doesn't exist yet.

The old `nix run .#bump` output told you to do exactly that (`git push origin HEAD v$new`), which now fails. This documents the correct flow in the two places a releaser looks.

## What

- **`nix run .#bump`** now prints the `branch → PR → merge → tag` steps instead of the old direct-push one-liner, and warns (with remediation) when it's run on `main`.
- **`CONTRIBUTING.md`** gains a **Releasing** section describing the same flow and why the tag push (not the merge) triggers the release/FlakeHub workflow.

No behavior change to the bump logic itself — only its printed guidance. Verified the app still builds (shellcheck passes via `writeShellApplication`) and the dry-run is unchanged.

## Changelog

Added under `[Unreleased] → Documentation`.