### PR TITLE
build: let pinned-optimize deps inherit the top-level optimize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ versioning; breaking changes to it bump the major version.
 
 ## [Unreleased]
 
+### Internal
+
+- Build: the `mvzr`, `clap`, preview-server, and report modules now inherit the
+  top-level `-Doptimize` instead of pinning `ReleaseSafe`/`ReleaseFast`, so a
+  single build compiles each dependency at one optimize level instead of
+  several (#138).
+
 ## [1.5.0] - 2026-07-15
 
 ### Security

--- a/build.zig
+++ b/build.zig
@@ -25,11 +25,11 @@ pub fn build(b: *std.Build) !void {
 
     const mvzr = b.dependency("mvzr", .{
         .target = target,
-        .optimize = .ReleaseSafe,
+        .optimize = optimize,
     });
     const clap = b.dependency("clap", .{
         .target = target,
-        .optimize = .ReleaseSafe,
+        .optimize = optimize,
     });
     // const zetta_dep = b.dependency("zetta", .{
     //     .target = target,
@@ -78,7 +78,7 @@ pub fn build(b: *std.Build) !void {
         const server_mod = b.addModule("server", .{
             .root_source_file = b.path("src/server.zig"),
             .target = target,
-            .optimize = .ReleaseFast,
+            .optimize = optimize,
         });
         server_mod.addImport("zap", zap.module("zap"));
         server_mod.addImport("clap", clap.module("clap"));
@@ -134,7 +134,7 @@ pub fn build(b: *std.Build) !void {
 
     const reports_mod = b.addModule("policy_report", .{
         .target = target,
-        .optimize = .ReleaseFast,
+        .optimize = optimize,
         .root_source_file = b.path("src/control_report.zig"),
     });
     reports_mod.addImport("clap", clap.module("clap"));


### PR DESCRIPTION
## Summary

Fixes #138.

`build.zig` pinned four modules to a fixed optimize level (`mvzr`/`clap` → ReleaseSafe; the preview server and `policy_report` → ReleaseFast). Since Zig compiles each dependency per (version × optimize × consumer), a single build compiled shared deps like `mvzr` and `clap` once per mode. All four now inherit the top-level `-Doptimize`, so within any one build every dependency compiles at a single level.

The fuzz module's `.Debug` pin is intentionally untouched (coverage-guided fuzzing).

Trade-off noted in the issue: plain `zig build` (Debug) now compiles the dev preview server and report module in Debug too — faster builds, dev-only runtime paths remain acceptable.

Not addressed here (possible follow-up from the issue): aligning the duplicate `mvzr`/`clap` versions that zigmark pins vs the direct deps.

## Verification

- `zig build test` — 56/56 pass (unit + golden)
- `nix flake check` runs in CI (required checks)