### PR TITLE
fix: navigation and mobile views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ versioning; breaking changes to it bump the major version.
 
 ## [Unreleased]
 
+### Internal
+
+- Build: the `mvzr`, `clap`, preview-server, and report modules now inherit the
+  top-level `-Doptimize` instead of pinning `ReleaseSafe`/`ReleaseFast`, so a
+  single build compiles each dependency at one optimize level instead of
+  several (#138).
+
 ## [1.5.0] - 2026-07-15
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,36 @@ versioning; breaking changes to it bump the major version.
   single build compiles each dependency at one optimize level instead of
   several (#138).
 
+### Added
+
+- **Reports and Guides joined the main navigation**, and both section indexes
+  now render as card landings (new `section-cards.html` template with title,
+  description, and link per page) instead of the bare default section list.
+  Report pages carry explicit weights so the landing orders SCF → SOC 2 →
+  Last Reviewed.
+
+### Fixed
+
+- **Navigation menu `weight` is honored.** It was documented as the sort
+  order but entries always rendered in file order; entries are now sorted by
+  weight when every entry carries one (file order otherwise, so existing
+  configs without weights keep working).
+- **Mobile and tablet layout fixes** across the site:
+  - The navbar now expands at the `lg` breakpoint instead of `md`, and the
+    search box shrinks instead of holding a fixed 20rem — five nav items plus
+    search no longer overflow the header between 768px and 991px.
+  - The docs sidebar starts collapsed behind its ☰ Menu button on small
+    screens (it rendered fully expanded above the content, forcing a long
+    scroll to reach the page; without JS it stays expanded).
+  - Page content is offset below the taller two-row fixed header on small
+    screens, so the sidebar toggle is no longer clipped underneath it.
+  - Wide markdown tables scroll horizontally on phones instead of overflowing
+    the page; the policy-review table wraps its columns cleanly.
+  - The homepage statistics band stacks on phones and lets long stats wrap
+    (previously `white-space: nowrap` clipped "Framework-ready" offscreen),
+    quick-action cards collapse to one column on narrow phones, and dashboard
+    stat tiles stack full-width instead of an asymmetric 8/12 column.
+
 ## [1.5.0] - 2026-07-15
 
 ### Security

--- a/build.zig
+++ b/build.zig
@@ -25,11 +25,11 @@ pub fn build(b: *std.Build) !void {
 
     const mvzr = b.dependency("mvzr", .{
         .target = target,
-        .optimize = .ReleaseSafe,
+        .optimize = optimize,
     });
     const clap = b.dependency("clap", .{
         .target = target,
-        .optimize = .ReleaseSafe,
+        .optimize = optimize,
     });
     // const zetta_dep = b.dependency("zetta", .{
     //     .target = target,
@@ -78,7 +78,7 @@ pub fn build(b: *std.Build) !void {
         const server_mod = b.addModule("server", .{
             .root_source_file = b.path("src/server.zig"),
             .target = target,
-            .optimize = .ReleaseFast,
+            .optimize = optimize,
         });
         server_mod.addImport("zap", zap.module("zap"));
         server_mod.addImport("clap", clap.module("clap"));
@@ -134,7 +134,7 @@ pub fn build(b: *std.Build) !void {
 
     const reports_mod = b.addModule("policy_report", .{
         .target = target,
-        .optimize = .ReleaseFast,
+        .optimize = optimize,
         .root_source_file = b.path("src/control_report.zig"),
     });
     reports_mod.addImport("clap", clap.module("clap"));

--- a/config.toml
+++ b/config.toml
@@ -229,18 +229,32 @@ icon = "fas fa-file-alt"
 weight = 10
 
 [[extra.menu.main]]
+title = "Reports"
+section = "reports"
+url = "/reports/"
+icon = "fas fa-chart-bar"
+weight = 20
+
+[[extra.menu.main]]
+title = "Guides"
+section = "guides"
+url = "/guides/"
+icon = "fas fa-book-open"
+weight = 30
+
+[[extra.menu.main]]
 title = "Team"
 section = "team"
 url = "/team/"
 icon = "fas fa-users"
-weight = 20
+weight = 40
 
 [[extra.menu.main]]
 title = "News"
 section = "news"
 url = "/news/"
 icon = "fas fa-newspaper"
-weight = 30
+weight = 50
 
 [extra.policyteam]
 [[extra.policyteam.members]]

--- a/content/guides/_index.md
+++ b/content/guides/_index.md
@@ -1,6 +1,10 @@
 +++
 title = "Guides"
+description = "Installation, configuration, and authoring guides"
+template = "section-cards.html"
 weight = 10
 sort_by = "weight"
 insert_anchor_links = "right"
 +++
+
+How to install, configure, and write policies with PolicyPress.

--- a/content/reports/_index.md
+++ b/content/reports/_index.md
@@ -1,6 +1,11 @@
 +++
 title = "Reports"
+description = "Compliance coverage and policy review reports"
+template = "section-cards.html"
 weight = 10
 sort_by = "weight"
 insert_anchor_links = "right"
 +++
+
+Live reports generated from the policy library: framework coverage and review
+status, always current with the latest build.

--- a/content/reports/review.md
+++ b/content/reports/review.md
@@ -2,6 +2,6 @@
 title = "Last Reviewed Report"
 description = "The Policy Last Reviewed Report"
 template = "reports/policy-review.html"
-weight = 1
+weight = 3
 [extra]
 +++

--- a/content/reports/soc2.md
+++ b/content/reports/soc2.md
@@ -2,7 +2,7 @@
 title = "SOC 2 Report"
 description = "SOC 2 Type II Policy Coverage Report"
 template = "TSC2017/list.html"
-weight = 1
+weight = 2
 [extra]
 +++
 

--- a/sass/common/_global.scss
+++ b/sass/common/_global.scss
@@ -94,6 +94,13 @@ a.btn:focus {
 
 body {
   padding-top: 3.5625rem;
+
+  // Below the navbar expansion breakpoint the fixed header stacks into two
+  // rows (toggler/brand + social), so the single-row offset clips the top of
+  // the page content (e.g. the sidebar's ☰ Menu button).
+  @include media-breakpoint-down(lg) {
+    padding-top: 6.5rem;
+  }
 }
 
 .docs-sidebar {
@@ -401,8 +408,8 @@ h6:hover > .zola-anchor {
 }
 
 // In-prose links get an underline so they are distinguishable from body text by
-// more than colour (WCAG 1.4.1). Excludes the heading anchor icon, buttons, and
-// badge-like links which are distinguished by shape/placement.
-.content a[href]:not(.zola-anchor):not(.btn):not(.badge) {
+// more than colour (WCAG 1.4.1). Excludes the heading anchor icon, buttons,
+// badge-like links, and card links which are distinguished by shape/placement.
+.content a[href]:not(.zola-anchor):not(.btn):not(.badge):not(.section-card) {
   text-decoration: underline;
 }

--- a/sass/components/_frontpage.scss
+++ b/sass/components/_frontpage.scss
@@ -216,6 +216,10 @@
         grid-template-columns: repeat(2, 1fr);
       }
 
+      @media (max-width: 576px) {
+        grid-template-columns: 1fr;
+      }
+
       .quick-action-card {
         background: var(--pp-card-bg);
         padding: 1.75rem;
@@ -285,15 +289,36 @@
       justify-content: center;
       gap: 4rem;
 
+      // The three nowrap stat columns overflow narrow viewports; stack them.
+      @media (max-width: 768px) {
+        flex-direction: column;
+        align-items: center;
+        gap: 1.5rem;
+      }
+
       .stat-item {
         text-align: center;
         width: 33%;
+
+        @media (max-width: 768px) {
+          width: 100%;
+        }
 
         .stat-number {
           font-size: 2.5rem;
           font-weight: 700;
           margin-bottom: 0.5rem;
           white-space: nowrap;
+
+          // A long stat (e.g. "Framework-ready") overflows narrow viewports
+          // at this size; let it wrap instead of forcing a horizontal scroll.
+          @media (max-width: 991px) {
+            white-space: normal;
+          }
+
+          @media (max-width: 768px) {
+            font-size: 2rem;
+          }
         }
 
         .stat-label {
@@ -302,6 +327,10 @@
           text-transform: uppercase;
           letter-spacing: 0.5px;
           white-space: nowrap;
+
+          @media (max-width: 991px) {
+            white-space: normal;
+          }
         }
       }
     }

--- a/sass/components/_search.scss
+++ b/sass/components/_search.scss
@@ -1,8 +1,12 @@
 .navbar-form {
   position: relative;
 
-  @include media-breakpoint-up(md) {
-    width: 20rem;
+  // In the expanded navbar the search sits on one line with the nav items;
+  // give it a generous basis but let it shrink so five nav items plus the
+  // search never overflow the container.
+  @include media-breakpoint-up(lg) {
+    flex: 0 1 20rem;
+    min-width: 8rem;
   }
 }
 

--- a/sass/components/_section-cards.scss
+++ b/sass/components/_section-cards.scss
@@ -1,0 +1,51 @@
+// Card-grid section landing (templates/section-cards.html): one linked card
+// per page, e.g. the /reports/ and /guides/ indexes.
+.section-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1.5rem;
+  margin: 2rem 0 3rem;
+
+  .section-card {
+    display: flex;
+    flex-direction: column;
+    padding: 1.75rem;
+    background: var(--pp-card-bg, var(--bs-body-bg));
+    border: 1px solid var(--bs-border-color);
+    border-radius: var(--pp-radius-md, 0.5rem);
+    box-shadow: var(--pp-shadow-sm, none);
+    color: var(--bs-body-color);
+    text-decoration: none;
+    transition: var(--pp-transition, none);
+
+    &:hover,
+    &:focus-visible {
+      transform: translateY(-2px);
+      box-shadow: var(--pp-shadow-md, none);
+      text-decoration: none;
+    }
+
+    h2 {
+      color: var(--bs-heading-color);
+      margin-bottom: 0.5rem;
+    }
+
+    p {
+      color: var(--bs-secondary-color);
+      font-size: 0.9rem;
+      line-height: 1.5;
+      margin-bottom: 1rem;
+    }
+
+    .section-card-cta {
+      margin-top: auto;
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: var(--bs-link-color);
+
+      i {
+        margin-left: 0.25rem;
+      }
+    }
+  }
+}

--- a/sass/components/_tables.scss
+++ b/sass/components/_tables.scss
@@ -4,6 +4,23 @@ table {
   margin: 3rem 0;
 }
 
+// On narrow screens a wide markdown table (version history, control matrices)
+// otherwise overflows the page with no scroll affordance.
+@include media-breakpoint-down(md) {
+  main table {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
+// Generic horizontal-scroll wrapper for non-<table> grids (e.g. the
+// policy-review date table, which is a CSS display:table of <div>s).
+.table-scroll {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
 // Split-color framework badges — label|count pill
 // Visually distinguishes the framework name from the coverage count
 // so "SCF | 6" reads as "6 SCF controls", not "version 6".

--- a/sass/layouts/_sidebar.scss
+++ b/sass/layouts/_sidebar.scss
@@ -42,6 +42,15 @@
   font-size: $font-size-sm;
 }
 
+// The sidebar tree starts collapsed on small screens (main.js removes .show on
+// load); on lg+ the toggle is hidden, so force the tree visible regardless of
+// the collapse state carried over from a small viewport.
+@include media-breakpoint-up(lg) {
+  #sidebarNav {
+    display: block;
+  }
+}
+
 // Content column: allow flexbox to shrink it below its content's natural width
 // so that wide mermaid diagrams don't push the TOC off screen.
 .policy-content-col {

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -29,6 +29,7 @@
 @import "components/tabs";
 @import "components/satisfies";
 @import "components/search";
+@import "components/section-cards";
 @import "components/syntax";
 @import "components/tables";
 @import "components/team";

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -58,6 +58,19 @@ document.addEventListener("click", function (e) {
   }
 });
 
+// On small screens the docs sidebar renders above the page content, so an
+// expanded tree forces a long scroll before the content. Start it collapsed
+// there (progressive enhancement: without JS it stays expanded, and on lg+
+// the toggle is hidden and CSS keeps the sidebar visible).
+(function collapseSidebarOnMobile() {
+  var sidebarNav = document.getElementById("sidebarNav");
+  if (!sidebarNav) return;
+  if (window.matchMedia("(min-width: 992px)").matches) return;
+  sidebarNav.classList.remove("show");
+  var toggle = document.querySelector('[data-bs-target="#sidebarNav"]');
+  if (toggle) toggle.setAttribute("aria-expanded", "false");
+})();
+
 // Sidebar desktop collapse toggle.
 var sidebarCol = document.getElementById("sidebar-col");
 var sidebarToggle = document.getElementById("sidebar-toggle");

--- a/templates/index.html
+++ b/templates/index.html
@@ -279,20 +279,20 @@ description=description, is_home=true) }}
       {# ---- Stat tiles ---- #}
       {% if policies | length > 0 %}
       <div class="row g-3 mb-4">
-        <div class="col-8 col-lg-4">
+        <div class="col-12 col-sm-6 col-lg-4">
           <div class="card h-100 text-center"><div class="card-body">
             <div class="h2 mb-0 fw-bold text-nowrap">{{ policies | length }}</div>
             <div class="text-muted small text-uppercase text-nowrap">Policies</div>
           </div></div>
         </div>
-        <div class="col-8 col-lg-4">
+        <div class="col-12 col-sm-6 col-lg-4">
           <div class="card h-100 text-center"><div class="card-body">
             <div class="h2 mb-0 fw-bold text-nowrap {% if overdue_count > 0 %}text-danger{% else %}text-success{% endif %}">{{ overdue_count }}</div>
             <div class="text-muted small text-uppercase text-nowrap">Reviews overdue</div>
           </div></div>
         </div>
         {% if scf_pct >= 0 %}
-        <div class="col-8 col-lg-4">
+        <div class="col-12 col-sm-6 col-lg-4">
           <div class="card h-100 text-center"><div class="card-body">
             <div class="h2 mb-0 fw-bold text-nowrap">{{ scf_pct }}%</div>
             <div class="text-muted small text-uppercase text-nowrap">SCF coverage</div>
@@ -300,7 +300,7 @@ description=description, is_home=true) }}
         </div>
         {% endif %}
         {% if tsc_pct >= 0 %}
-        <div class="col-8 col-lg-4">
+        <div class="col-12 col-sm-6 col-lg-4">
           <div class="card h-100 text-center"><div class="card-body">
             <div class="h2 mb-0 fw-bold text-nowrap">{{ tsc_pct }}%</div>
             <div class="text-muted small text-uppercase text-nowrap">SOC 2 coverage</div>

--- a/templates/macros/header.html
+++ b/templates/macros/header.html
@@ -1,19 +1,19 @@
 {% macro header(current_section) %}
-<header class="navbar fixed-top navbar-expand-md navbar-light my-auto">
+<header class="navbar fixed-top navbar-expand-lg navbar-light my-auto">
 	<div class="container">
-		<button class="navbar-toggler d-md-none order-0" type="button"
+		<button class="navbar-toggler d-lg-none order-0" type="button"
 			data-bs-toggle="collapse" data-bs-target="#navbarMain"
 			aria-controls="navbarMain" aria-expanded="false"
 			aria-label="Toggle navigation">
 			<span class="navbar-toggler-icon"></span>
 		</button>
-		<a class="navbar-brand order-1 order-md-0 me-auto"
+		<a class="navbar-brand order-1 order-lg-0 me-auto"
 			href="{{ config.base_url | safe }}"><img class="brand-logo"
 				alt="{{ config.extra.policypress.organization | default(value=config.title | default(value='PolicyPress')) }} logo"
 				src="{{ get_url(path=config.extra.menu.logo) }}">{{
 			config.title |
 			default(value="PolicyPress") }}</a>
-		<button id="mode" class="btn btn-link order-2 order-md-4" type="button"
+		<button id="mode" class="btn btn-link order-2 order-lg-4" type="button"
 			aria-label="Toggle mode">
 			<span class="toggle-dark"><svg xmlns="http://www.w3.org/2000/svg" width="20"
 					height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor"
@@ -31,7 +31,7 @@
 						x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36"
 						y1="5.64" x2="19.78" y2="4.22"></line></svg></span>
 		</button>
-		<ul class="navbar-nav fork-me order-3 order-md-5">
+		<ul class="navbar-nav fork-me order-3 order-lg-5">
 			{% if config.extra.menu.social %}
 			{% for val in config.extra.menu.social %}
 			<li class="nav-item">
@@ -41,8 +41,8 @@
 			{% endfor %}
 			{% endif %}
 		</ul>
-		<div id="navbarMain" class="collapse navbar-collapse order-4 order-md-1">
-			<ul class="navbar-nav main-nav me-auto order-5 order-md-2">
+		<div id="navbarMain" class="collapse navbar-collapse order-4 order-lg-1">
+			<ul class="navbar-nav main-nav me-auto order-5 order-lg-2">
 				{% if lang == config.default_language %}
 				{% set rootsectionpath = "_index.md" %}
 				{% else %}
@@ -50,16 +50,19 @@
 				{% endif %}
 				{% set mainsec = get_section(path=rootsectionpath) %}
 				{% if mainsec.extra.menu.main %}
-				{% for val in mainsec.extra.menu.main %}
-				<li
-					class="nav-item{% if current_section == val.section %} {{ current_section }} active{% endif %}">
-					<a class="nav-link"
-						href="{{ get_url(path=val.url, trailing_slash=true) | safe }}">{{
-						val.title }}</a>
-				</li>
-				{% endfor %}
+				{% set menu_main = mainsec.extra.menu.main %}
 				{% elif config.extra.menu.main %}
-				{% for val in config.extra.menu.main %}
+				{% set menu_main = config.extra.menu.main %}
+				{% else %}
+				{% set menu_main = false %}
+				{% endif %}
+				{% if menu_main %}
+				{# `weight` is documented as the sort order but is optional; only sort
+				   when every entry carries it (Tera's sort errors on a missing key). #}
+				{% if menu_main | filter(attribute="weight") | length == menu_main | length %}
+				{% set menu_main = menu_main | sort(attribute="weight") %}
+				{% endif %}
+				{% for val in menu_main %}
 				<li
 					class="nav-item{% if current_section == val.section %} {{ current_section }} active{% endif %}">
 					<a class="nav-link"
@@ -79,9 +82,9 @@
 				</li>
 				{% endif %}
 			</ul>
-			<div class="break order-6 d-md-none"></div>
+			<div class="break order-6 d-lg-none"></div>
 			{% if config.build_search_index %}
-			<form class="navbar-form ms-auto order-8 order-md-3" role="search">
+			<form class="navbar-form ms-auto order-8 order-lg-3" role="search">
 				<input id="userinput" class="form-control is-search" type="search"
 					placeholder="Search policies..."
 					aria-label="Search policies..." autocomplete="off"

--- a/templates/reports/policy-review.html
+++ b/templates/reports/policy-review.html
@@ -8,6 +8,7 @@
 {% set_global policies = policies | concat(with=subsection.pages) %}
 {% endfor %}
 
+<div class="table-scroll">
 <div class="policy-review-date-table">
       <div class="row">
         <div class="header">Policy</div>
@@ -39,4 +40,5 @@
       </div>
       {% endfor %}
     </div>
+</div>
 {% endblock report_content %}

--- a/templates/section-cards.html
+++ b/templates/section-cards.html
@@ -1,0 +1,64 @@
+{# Card-grid landing for a section: one card per page, title + description.
+   Opt in from a section's _index.md with `template = "section-cards.html"`.
+   Used by the demo's /reports/ and /guides/ sections. #}
+
+{% extends "base.html" %}
+
+{% block seo %}
+{{ super() }}
+{% set title_addition = "" %}
+
+{% if section.title and config.title %}
+{% set title = section.title %}
+{% set title_addition = title_separator ~ config.title %}
+{% elif section.title %}
+{% set title = section.title %}
+{% else %}
+{% set title = config.title %}
+{% endif %}
+
+{% if section.description %}
+{% set description = section.description %}
+{% else %}
+{% set description = config.description %}
+{% endif %}
+
+{{ macros_head::seo(title=title, title_addition=title_addition,
+description=description) }}
+{% endblock seo %}
+
+{% block body %}
+{% set page_class = "page list section-cards" %}
+{% endblock body %}
+
+{% block content %}
+<main id="main-content">
+  <div class="page-header">
+    <h1>{{ section.title }}</h1>
+  </div>
+  {{ section.content | safe }}
+  <div class="section-card-grid">
+    {% for page in section.pages %}
+    <a class="section-card" href="{{ page.permalink | safe }}">
+      <h2 class="h5">{{ page.title }}</h2>
+      {% if page.description %}
+      <p>{{ page.description }}</p>
+      {% endif %}
+      <span class="section-card-cta" aria-hidden="true">View
+        <i class="fas fa-arrow-right"></i></span>
+    </a>
+    {% endfor %}
+    {% for subsec in section.subsections %}
+    {% set sec_ = get_section(path=subsec) %}
+    <a class="section-card" href="{{ sec_.permalink | safe }}">
+      <h2 class="h5">{{ sec_.title }}</h2>
+      {% if sec_.description %}
+      <p>{{ sec_.description }}</p>
+      {% endif %}
+      <span class="section-card-cta" aria-hidden="true">View
+        <i class="fas fa-arrow-right"></i></span>
+    </a>
+    {% endfor %}
+  </div>
+</main>
+{% endblock content %}


### PR DESCRIPTION
## Summary

Second PR in the batch (stacked on #142; merge that first and GitHub retargets this to `main`).

Navigation:
- **Reports and Guides join the main nav** — they were only reachable via homepage links. Both section indexes render as card landings via a new `section-cards.html` template (title + description + link per page) instead of the bare default section list.
- **Menu `weight` is honored.** Documented as the sort order but never sorted; now sorted when every entry carries a weight, file order otherwise (guarded so existing configs without weights keep building — verified with a build).

Mobile/tablet:
- **Navbar expands at `lg` instead of `md`, and the search box flex-shrinks.** Five items + a fixed 20rem search overflowed every viewport between 768-991px (measured 239px of overflow at 768px).
- **Docs sidebar starts collapsed behind its ☰ Menu button on small screens** — it rendered fully expanded above the content, forcing a scroll past the whole site tree to reach any report. Progressive enhancement: without JS it stays expanded; on lg+ CSS keeps it visible regardless.
- **Content offset below the two-row fixed header** on small screens (the sidebar toggle was clipped underneath it).
- **Wide markdown tables scroll horizontally on phones**; the policy-review table wraps its three columns cleanly.
- **Homepage statistics band** stacks on phones and wraps long stats — `white-space: nowrap` clipped "Framework-ready" off the right edge at 390px and forced an 884px scroll width at 820px. Quick-action cards collapse to one column; dashboard stat tiles go `col-12 col-sm-6 col-lg-4` instead of the asymmetric `col-8`.

## Verification

- `zola build` green; headless-chromium screenshot sweep at 390/768/820/992/1024/1400px in light+dark: no horizontal overflow on any checked page (was 884px scroll width at 820px before)
- axe-core scan (the CI gate): **PASS — 0 violations across 9 pages × 2 modes**, including the new card landings