### PR TITLE
ci: move CI logic into flake apps + a shared release-guard script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,39 +44,16 @@ jobs:
           # against the previous tag.
           fetch-depth: 0
 
-      # Authoritative backstop for the local pre-push hook (.githooks/pre-push):
-      # a release tag must include a CHANGELOG.md change since the previous tag.
-      # Cannot be bypassed with `git push --no-verify`.
-      - name: Require CHANGELOG update for release tag
+      # Release-tag guards, before the nix install for fail-fast (they need
+      # only git + grep): CHANGELOG.md changed since the previous tag, and the
+      # version stamped in build.zig.zon/config.toml matches the tag. The logic
+      # lives in tools/check-release.sh so it runs identically here, locally
+      # (bash tools/check-release.sh <tag>), and via `nix run .#check-release`.
+      # This is the authoritative backstop for the local .githooks/pre-push
+      # CHANGELOG check (which `git push --no-verify` can skip).
+      - name: Release-tag guards (CHANGELOG + version stamp)
         if: ${{ github.ref_type == 'tag' && matrix.os == 'ubuntu-latest' }}
-        run: |
-          tag="${{ github.ref_name }}"
-          prev="$(git describe --tags --abbrev=0 "${tag}^" 2>/dev/null || true)"
-          if [ -z "$prev" ]; then
-            echo "No previous tag; skipping CHANGELOG check."
-            exit 0
-          fi
-          if git diff --quiet "$prev" "$tag" -- CHANGELOG.md; then
-            echo "::error::CHANGELOG.md has no changes between $prev and $tag. Update the changelog (e.g. 'nix run .#bump') before releasing."
-            exit 1
-          fi
-          echo "CHANGELOG.md updated since $prev ✓"
-
-      # Releases are cut from the tag exactly as pushed (CI no longer stamps and
-      # force-moves the tag). Guard that the maintainer stamped the version
-      # before tagging so the release binary can't disagree with the tag.
-      - name: Verify version is stamped to match the release tag
-        if: ${{ github.ref_type == 'tag' && matrix.os == 'ubuntu-latest' }}
-        run: |
-          version="${{ github.ref_name }}"
-          version="${version#v}"
-          zon_version="$(grep -oP '\.version = "\K[^"]+' build.zig.zon | head -1)"
-          toml_version="$(grep -oP '^version = "\K[^"]+' config.toml | head -1)"
-          if [ "$zon_version" != "$version" ] || [ "$toml_version" != "$version" ]; then
-            echo "::error::Version drift: tag=$version, build.zig.zon=$zon_version, config.toml=$toml_version. Run 'nix run .#bump ${version}' and commit before tagging."
-            exit 1
-          fi
-          echo "Version $version is stamped in build.zig.zon and config.toml ✓"
+        run: bash tools/check-release.sh "${{ github.ref_name }}"
 
       - name: Install Nix
         uses: DeterminateSystems/determinate-nix-action@c70cb8ae92d68c66953db28a26a63db1665bc837 # v3
@@ -112,27 +89,19 @@ jobs:
             om ci run
           fi
 
-      # End-to-end guard for the redaction feature: build the demo site and
-      # redacted PDFs and assert no {% redact() %} content survives into the
-      # published site (HTML, search index, feeds) or the PDF output dir.
-      - name: Redaction leak check
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        shell: nix develop --command bash -e {0}
-        run: |
-          zig build
-          bash tests/redaction-leak-check.sh
+      # The redaction leak check runs as the `redaction-leak` flake check via
+      # `om ci run` above, so it is not repeated as a separate step here.
 
       # Web accessibility gate: serve the site and run axe-core (vendored) over a
       # representative page of every template in light and dark mode; fail on any
-      # WCAG A/AA violation. chromium + node come from nixpkgs (no npm).
+      # WCAG A/AA violation. The `a11y-scan` flake app pins chromium + node +
+      # zola (no floating nixpkgs# reference) and is runnable locally too.
       - name: Accessibility scan (axe-core)
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        shell: nix develop --command bash -e {0}
         env:
           # Structured results for the attestation-evidence artifact below.
           A11Y_REPORT: evidence/a11y-report.json
-        run: |
-          nix shell nixpkgs#chromium nixpkgs#nodejs --command bash tests/a11y/scan.sh
+        run: nix run .#a11y-scan
 
       # Self-attestation evidence: SBOM (CycloneDX from the Zig lock file),
       # per-check records with logs, the veraPDF PDF/UA-1 reports (the
@@ -148,11 +117,8 @@ jobs:
         if: ${{ success() && matrix.os == 'ubuntu-latest' && (github.ref_type == 'tag' || github.ref_name == 'main' || (github.event_name == 'pull_request' && github.base_ref == 'main')) }}
         run: |
           mkdir -p evidence
-          nix develop --command bash -c '
-            set -euo pipefail
-            tools/sbom.sh > evidence/sbom.cdx.json
-            tools/check-evidence.sh evidence
-          '
+          nix run .#sbom > evidence/sbom.cdx.json
+          nix run .#check-evidence -- evidence
           mkdir -p evidence/verapdf
           cp -rL "$(nix build --no-link --print-out-paths .#checks.x86_64-linux.pdf-accessibility)"/. evidence/verapdf/
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ sbom.cdx.json
 sbom.spdx.json
 sbom.csv
 http_cache.sqlite
+
+# CI attestation evidence (generated; uploaded as an artifact, never committed)
+evidence/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ versioning; breaking changes to it bump the major version.
   printed "command not found" on every shell entry (no `zig2nix` binary is on
   `PATH`; the lock regenerator is the zig2nix flake app `zon2json-lock`, run
   deliberately via `nix run .#update-zon`).
+- **CI logic moved out of the workflow YAML into flake apps and a shared
+  script**, so it runs identically locally and in CI with pinned tools:
+  `nix run .#sbom`, `.#check-evidence`, and `.#a11y-scan` (the last pins
+  chromium/node/zola instead of a floating `nixpkgs#…` reference), plus
+  `tools/check-release.sh` (the tag CHANGELOG + version-stamp guards, also
+  `nix run .#check-release`). The redundant "Redaction leak check" workflow
+  step was dropped — it duplicated the `redaction-leak` flake check that
+  `om ci run` already runs.
 - Build: the `mvzr`, `clap`, preview-server, and report modules now inherit the
   top-level `-Doptimize` instead of pinning `ReleaseSafe`/`ReleaseFast`, so a
   single build compiles each dependency at one optimize level instead of

--- a/flake.nix
+++ b/flake.nix
@@ -420,6 +420,82 @@
                 meta.description = "Run policypress with all runtime dependencies in PATH";
               };
 
+            # Attestation-evidence generators, exposed as flake apps so they run
+            # identically in CI and locally (`nix run .#sbom`, `.#check-evidence`,
+            # `.#a11y-scan`) with their tools pinned by this flake rather than a
+            # floating `nixpkgs#…` reference. Each is a thin wrapper: it puts the
+            # required tools on PATH (keeping the ambient PATH so an outer `nix`
+            # stays reachable for check-evidence) and runs the script in tools/,
+            # which remains the source of truth and directly runnable.
+            apps.sbom = {
+              type = "app";
+              program = "${pkgs.writeShellScript "policypress-sbom" ''
+                export PATH="${
+                  lib.makeBinPath (
+                    [
+                      pkgs.jq
+                      pkgs.git
+                    ]
+                    ++ runtimeDeps
+                  )
+                }:$PATH"
+                cd "$(git rev-parse --show-toplevel)"
+                exec bash tools/sbom.sh "$@"
+              ''}";
+              meta.description = "Generate the CycloneDX SBOM (tools/sbom.sh)";
+            };
+
+            apps.check-evidence = {
+              type = "app";
+              program = "${pkgs.writeShellScript "policypress-check-evidence" ''
+                export PATH="${
+                  lib.makeBinPath [
+                    pkgs.jq
+                    pkgs.git
+                  ]
+                }:$PATH"
+                cd "$(git rev-parse --show-toplevel)"
+                exec bash tools/check-evidence.sh "$@"
+              ''}";
+              meta.description = "Record flake-check evidence (tools/check-evidence.sh)";
+            };
+
+            apps.a11y-scan = {
+              type = "app";
+              program = "${pkgs.writeShellScript "policypress-a11y-scan" ''
+                export PATH="${
+                  lib.makeBinPath (
+                    [
+                      pkgs.chromium
+                      pkgs.nodejs
+                      pkgs.curl
+                      pkgs.coreutils
+                    ]
+                    ++ runtimeDeps
+                  )
+                }:$PATH"
+                cd "$(git rev-parse --show-toplevel)"
+                exec bash tests/a11y/scan.sh "$@"
+              ''}";
+              meta.description = "axe-core WCAG scan of the served site (tests/a11y/scan.sh)";
+            };
+
+            apps.check-release = {
+              type = "app";
+              program = "${pkgs.writeShellScript "policypress-check-release" ''
+                export PATH="${
+                  lib.makeBinPath [
+                    pkgs.git
+                    pkgs.gnugrep
+                    pkgs.coreutils
+                  ]
+                }:$PATH"
+                cd "$(git rev-parse --show-toplevel)"
+                exec bash tools/check-release.sh "$@"
+              ''}";
+              meta.description = "Release-tag guards: CHANGELOG + version stamp (tools/check-release.sh)";
+            };
+
             apps.serve =
               let
                 app = pkgs.writeShellApplication {

--- a/tools/check-release.sh
+++ b/tools/check-release.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Release-tag guards, runnable locally (`bash tools/check-release.sh v1.6.0`)
+# and in CI (`nix run .#check-release -- "$tag"`). Two checks:
+#   1. CHANGELOG.md changed since the previous release tag (so a release always
+#      documents itself). Skipped when there is no previous tag (first release).
+#   2. The version stamped in build.zig.zon and config.toml matches the tag, so
+#      the released binary can never disagree with the tag it was cut from.
+# `::error::` lines are GitHub Actions annotations; harmless when run locally.
+set -euo pipefail
+
+tag="${1:?usage: check-release.sh <tag>}"
+version="${tag#v}"
+status=0
+
+# 1. CHANGELOG updated since the previous release tag.
+prev="$(git describe --tags --abbrev=0 "${tag}^" 2>/dev/null || true)"
+if [ -z "$prev" ]; then
+  echo "No previous tag before $tag; skipping CHANGELOG check."
+elif git diff --quiet "$prev" "$tag" -- CHANGELOG.md; then
+  echo "::error::CHANGELOG.md has no changes between $prev and $tag. Update the changelog (e.g. 'nix run .#bump') before releasing."
+  status=1
+else
+  echo "CHANGELOG.md updated since $prev ✓"
+fi
+
+# 2. Version stamped in build.zig.zon and config.toml matches the tag.
+zon_version="$(grep -oP '\.version = "\K[^"]+' build.zig.zon | head -1)"
+toml_version="$(grep -oP '^version = "\K[^"]+' config.toml | head -1)"
+if [ "$zon_version" != "$version" ] || [ "$toml_version" != "$version" ]; then
+  echo "::error::Version drift: tag=$version, build.zig.zon=$zon_version, config.toml=$toml_version. Run 'nix run .#bump ${version}' and commit before tagging."
+  status=1
+else
+  echo "Version $version is stamped in build.zig.zon and config.toml ✓"
+fi
+
+exit "$status"


### PR DESCRIPTION
The three "nix-native" moves discussed after the attestation work: push portable CI substance out of the workflow YAML into the flake so it runs identically locally and in CI with pinned tools, leaving ci.yml a thin GitHub adapter.

## Changes

- **Evidence generators are flake apps** — `nix run .#sbom`, `.#check-evidence`, `.#a11y-scan`. Each wraps the existing `tools/` or `tests/a11y` script (still the source of truth, still directly runnable) with its deps on PATH. `a11y-scan` pins chromium + node + zola instead of the floating `nixpkgs#chromium` / `nixpkgs#nodejs` the workflow used. ci.yml now calls the apps.
- **Release-tag guards → `tools/check-release.sh`** (+ `nix run .#check-release`). The two inline YAML guard steps (CHANGELOG changed since the previous tag; version stamped to match the tag) collapse into one locally-runnable script, kept before the nix install for fail-fast. Still the authoritative backstop for the `.githooks/pre-push` CHANGELOG check.
- **Dropped the redundant "Redaction leak check" step** — it re-ran the `redaction-leak` flake check that `om ci run` already runs.

Deliberately left GitHub-specific (the irreducible adapter layer): nix/cache setup, artifact upload, GitHub Release creation, tag moving, PR/tag `if:` gating.

## Verification

- All **10 flake checks pass** (via `nix run .#check-evidence`, which is how CI collects them).
- `nix run .#sbom` → valid CycloneDX 1.5, 16 components.
- `nix run .#a11y-scan` → PASS, 0 violations, report written.
- `tools/check-release.sh v1.5.0` and `nix run .#check-release -- v1.5.0` pass; `nix fmt` clean; ci.yml valid YAML.