### PR TITLE
feat: TeX math + authored images in policy PDFs (#140, #136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,20 @@ versioning; breaking changes to it bump the major version.
 
 ### Added
 
+- **TeX math now renders in policy PDFs** (#140). Set `extra.math = true` in a
+  policy's front matter — the same opt-in that already enables KaTeX on the
+  website — and `$…$`/`$$…$$` math renders in the PDF via the Typst `mitex`
+  package instead of appearing as literal dollar-text. Off by default, so
+  every non-math policy's PDF is byte-identical. The `mitex` package is
+  vendored into the offline Typst build, so no network access is needed at
+  build time. Tagged (PDF/UA-1) builds stay conformant: the preamble sets a
+  document-wide equation alt-text fallback, which typst's UA-1 mode requires.
+- **Markdown image alt text now carries into tagged PDFs** (#136). A Markdown
+  image's alt text (`![description](…)`) becomes the Typst `image(alt: …)`
+  argument, so images satisfy PDF/UA-1's alt-text requirement with a real
+  description rather than only the document-wide "Diagram" fallback (kept for
+  images with no alt source, such as rendered mermaid diagrams). Comes with the
+  zigmark v0.9.0 upgrade.
 - **Opt-in machine-readable audit bundle** (#135). `--audit-bundle` (or
   `[extra.policypress] audit_bundle = true`, or the action's `audit_bundle`
   input) writes an `audit/` directory beside the PDFs: `manifest.json` (one
@@ -93,6 +107,11 @@ versioning; breaking changes to it bump the major version.
 
 ### Fixed
 
+- **A trailing `# comment` after a front-matter value no longer breaks the
+  build.** YAML like `last_reviewed: 2025-01-01  # last audit` or a commented
+  revision date previously failed the whole policy with a parse error; the
+  zigmark v0.9.0 upgrade (which pins the sc2in/zig-yaml 0.3.1 "comment
+  terminates a plain scalar" fix) parses it cleanly.
 - **Fixes from the batch self-review**: the two-row header offset now
   actually applies on tablet widths (a pre-existing `4rem !important` rule
   overrode it between 768–991px); the homepage "Reviews overdue" tile and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,14 +54,15 @@ versioning; breaking changes to it bump the major version.
   package instead of appearing as literal dollar-text. Off by default, so
   every non-math policy's PDF is byte-identical. The `mitex` package is
   vendored into the offline Typst build, so no network access is needed at
-  build time. Tagged (PDF/UA-1) builds stay conformant: the preamble sets a
-  document-wide equation alt-text fallback, which typst's UA-1 mode requires.
+  build time. Tagged (PDF/UA-1) builds stay conformant: each equation carries
+  its own alt text (its TeX source, via zigmark v0.10.0), which typst's UA-1
+  mode requires.
 - **Markdown image alt text now carries into tagged PDFs** (#136). A Markdown
   image's alt text (`![description](…)`) becomes the Typst `image(alt: …)`
   argument, so images satisfy PDF/UA-1's alt-text requirement with a real
   description rather than only the document-wide "Diagram" fallback (kept for
   images with no alt source, such as rendered mermaid diagrams). Comes with the
-  zigmark v0.9.0 upgrade.
+  zigmark v0.10.0 upgrade.
 - **Opt-in machine-readable audit bundle** (#135). `--audit-bundle` (or
   `[extra.policypress] audit_bundle = true`, or the action's `audit_bundle`
   input) writes an `audit/` directory beside the PDFs: `manifest.json` (one
@@ -110,7 +111,7 @@ versioning; breaking changes to it bump the major version.
 - **A trailing `# comment` after a front-matter value no longer breaks the
   build.** YAML like `last_reviewed: 2025-01-01  # last audit` or a commented
   revision date previously failed the whole policy with a parse error; the
-  zigmark v0.9.0 upgrade (which pins the sc2in/zig-yaml 0.3.1 "comment
+  zigmark v0.10.0 upgrade (which pins the sc2in/zig-yaml 0.3.1 "comment
   terminates a plain scalar" fix) parses it cleanly.
 - **Fixes from the batch self-review**: the two-row header offset now
   actually applies on tablet widths (a pre-existing `4rem !important` rule

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ versioning; breaking changes to it bump the major version.
 
 ### Internal
 
+- **The SBOM now lists the `mitex` Typst package** as a `typst-package`
+  component, modelled as a dependency of `typst` in the CycloneDX graph. It is
+  vendored into the offline Typst cache and runs at compile time to render
+  math, so a CVE in it affects the PDF output — the same rationale that already
+  puts typst/zola in the SBOM. Version is read from the `@preview/mitex:`
+  import in `src/typst.zig` (which CI's math build forces to match the vendored
+  package).
 - **CI now produces self-attestation evidence.** Every push to `main`, every
   release tag, **and every pull request to `main`** uploads an
   `attestation-evidence` artifact (90-day retention) containing: a CycloneDX

--- a/build.zig
+++ b/build.zig
@@ -272,6 +272,7 @@ pub fn build(b: *std.Build) !void {
             .{ .name = "test_policy_redacted.typ", .fixture = "src/test/test_policy.md", .flag = "--redact" },
             .{ .name = "test_policy_draft.typ", .fixture = "src/test/test_policy.md", .flag = "--draft" },
             .{ .name = "test_policy_render.typ", .fixture = "src/test/test_policy_render.md", .flag = null },
+            .{ .name = "test_policy_math.typ", .fixture = "src/test/test_policy_math.md", .flag = null },
             .{ .name = "report_scf.typ", .fixture = "--report", .flag = "scf" },
             .{ .name = "report_soc2.typ", .fixture = "--report", .flag = "soc2" },
             .{ .name = "report_review.typ", .fixture = "--report", .flag = "review" },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -42,8 +42,8 @@
         // Switch to git+https URLs with hashes before publishing to FlakeHub.
         // .zetta = .{ .path = "../zetta" },
         .zigmark = .{
-            .url = "git+https://github.com/sc2in/zigmark?ref=v0.8.0#3bf2c1c9dee118a32f25344710eac4fb97d1bf94",
-            .hash = "zigmark-0.8.0-cwOiyAuwCgAwb2OCEWY8nA3F2tvEssKQiaTDVQMPptuN",
+            .url = "git+https://github.com/sc2in/zigmark?ref=v0.9.0#a95adc24948bbd0e389732b983445129b3ea4a33",
+            .hash = "zigmark-0.9.0-cwOiyCYHCwBM0yjOubWrly5CN2jUOalRJUdyLVLVQJJ6",
         },
         .tomlz = .{
             .url = "git+https://github.com/sc2in/tomlz.git#ecd64e239768b573ec58286d0db1842991433e99",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -42,8 +42,8 @@
         // Switch to git+https URLs with hashes before publishing to FlakeHub.
         // .zetta = .{ .path = "../zetta" },
         .zigmark = .{
-            .url = "git+https://github.com/sc2in/zigmark?ref=v0.9.0#a95adc24948bbd0e389732b983445129b3ea4a33",
-            .hash = "zigmark-0.9.0-cwOiyCYHCwBM0yjOubWrly5CN2jUOalRJUdyLVLVQJJ6",
+            .url = "git+https://github.com/sc2in/zigmark?ref=v0.10.0#23d12b74dfe586c36f7a7cfd5350719c067cc2a6",
+            .hash = "zigmark-0.10.0-cwOiyOMRCwDf1Z62LEuDj6DCDL1M-vzAFdh969E6Rpl_",
         },
         .tomlz = .{
             .url = "git+https://github.com/sc2in/tomlz.git#ecd64e239768b573ec58286d0db1842991433e99",

--- a/build.zig.zon2json-lock
+++ b/build.zig.zon2json-lock
@@ -1,8 +1,8 @@
 {
-  "zigmark-0.8.0-cwOiyAuwCgAwb2OCEWY8nA3F2tvEssKQiaTDVQMPptuN": {
+  "zigmark-0.9.0-cwOiyCYHCwBM0yjOubWrly5CN2jUOalRJUdyLVLVQJJ6": {
     "name": "zigmark",
-    "url": "git+https://github.com/sc2in/zigmark?ref=v0.8.0#3bf2c1c9dee118a32f25344710eac4fb97d1bf94",
-    "hash": "sha256-zKLpC3SUaaYAwE1FEDq+cam/ohzR3gAnZ2lNjtsOQZk="
+    "url": "git+https://github.com/sc2in/zigmark?ref=v0.9.0#a95adc24948bbd0e389732b983445129b3ea4a33",
+    "hash": "sha256-aJyVKWvfRAvATYgZo6S0M4vAQmehbqvSrzm9LOBmckM="
   },
   "tomlz-0.3.0-H2E6w3VKAgCSZQFKG-VugLEn3cjOWshGqwGzAVABNm--": {
     "name": "tomlz",
@@ -44,10 +44,10 @@
     "url": "git+https://github.com/mnemnion/mvzr?ref=v0.3.10#dd0e1bd2d6b10f9650317b30baef7ab7bc9dd9ec",
     "hash": "sha256-hUGdJPjC1PAm6zWL9eAE7A+wAfzf6Q7uSutT2Xe7EMU="
   },
-  "zig_yaml-0.3.0-C1161oSpAgCiEJXrktVkXNSWNQifQ8NWvNB-20PqoFc3": {
+  "zig_yaml-0.3.1-C1161s2zAgBOYGjCQB3uWdAadPevfdNiTaffefbhAhBq": {
     "name": "yaml",
-    "url": "git+https://github.com/sc2in/zig-yaml#691a2c37f1546fe843f7080fd7bf4450f1facb2e",
-    "hash": "sha256-8BNs41Ch8CmvRME13b6xXTD6VN2/2LewIsW7kp30tCY="
+    "url": "git+https://github.com/sc2in/zig-yaml#7c60d9cd6ae596c8247ac74b5b8e32c329e7c1d0",
+    "hash": "sha256-JAYq7B7gXd4+c60KXZ9b5IuaKLY7x7Bn9TNynyx4kog="
   },
   "mvzr-0.3.9-ZSOky6t2AQCA7efmm5EYbPb5sOdbXa4EFsUgYbQ6hZv9": {
     "name": "mvzr",

--- a/build.zig.zon2json-lock
+++ b/build.zig.zon2json-lock
@@ -1,8 +1,8 @@
 {
-  "zigmark-0.9.0-cwOiyCYHCwBM0yjOubWrly5CN2jUOalRJUdyLVLVQJJ6": {
+  "zigmark-0.10.0-cwOiyOMRCwDf1Z62LEuDj6DCDL1M-vzAFdh969E6Rpl_": {
     "name": "zigmark",
-    "url": "git+https://github.com/sc2in/zigmark?ref=v0.9.0#a95adc24948bbd0e389732b983445129b3ea4a33",
-    "hash": "sha256-aJyVKWvfRAvATYgZo6S0M4vAQmehbqvSrzm9LOBmckM="
+    "url": "git+https://github.com/sc2in/zigmark?ref=v0.10.0#23d12b74dfe586c36f7a7cfd5350719c067cc2a6",
+    "hash": "sha256-pOMqX6x9EAfu8JyoWH6L4j26wtBX+86n6qjRn8P2MI0="
   },
   "tomlz-0.3.0-H2E6w3VKAgCSZQFKG-VugLEn3cjOWshGqwGzAVABNm--": {
     "name": "tomlz",

--- a/content/policies/example-security-policy.md
+++ b/content/policies/example-security-policy.md
@@ -82,6 +82,8 @@ All access to information systems must be authorized and based on the principle 
 | Internal | Information for internal use only | Internal memos, policies | Access controls required |
 | Confidential | Sensitive information requiring protection | {% redact() %}Customer data, financial records, trade secrets{% end %} | Encryption required, strict access controls |
 
+![Data classification tiers: Public with standard controls, Internal with access controls, and Confidential requiring encryption and strict access, ordered from lower to higher sensitivity](/data-classification.svg)
+
 ### 3. Encryption Standards
 
 All sensitive data must be encrypted both at rest and in transit:

--- a/flake.nix
+++ b/flake.nix
@@ -803,11 +803,23 @@
                   zig2nix.outputs.packages.${system}."zls-0_16_0"
                   (pkgs.writeShellScriptBin "update-zon" ''
                     set -euo pipefail
-                    echo "Updating build.zig.zon dependencies..."
-                    zig fetch --save .
-                    echo "Regenerating build.zig.zon2json-lock..."
-                    zig2nix zon2lock
-                    echo "Done."
+                    # Regenerate build.zig.zon2json-lock after a dependency bump.
+                    #
+                    # To bump a dep, first edit its URL in build.zig.zon and
+                    # refresh that dep's hash (a bare `zig fetch --save .` hangs
+                    # here, so update the one dep by name):
+                    #   zig fetch --save=<name> "git+https://…?ref=vX.Y.Z#<commit>"
+                    # then run `update-zon`.
+                    echo "Fetching the full dependency graph…"
+                    zig build --fetch
+                    echo "Regenerating build.zig.zon2json-lock…"
+                    # zig2nix has no plain `zig2nix` binary on PATH; its CLI is
+                    # the flake app, pinned here so this never hits the network.
+                    ${zig2nix.apps.${system}.default.program} zon2lock
+                    # zon2lock omits the trailing newline that the end-of-file-fixer
+                    # pre-commit hook requires; add exactly one.
+                    [ -n "$(tail -c1 build.zig.zon2json-lock)" ] && printf '\n' >> build.zig.zon2json-lock
+                    echo "Done. Review with: git diff build.zig.zon2json-lock"
                   '')
                 ];
 
@@ -826,12 +838,11 @@
                 fi
 
                 # build.zig.zon2json-lock is committed and regenerated
-                # deliberately on a dependency bump with `nix run .#update-zon`.
-                # (There is no `zig2nix` binary on PATH — the lock regenerator
-                # is the zig2nix flake app `zon2json-lock` — so the previous
-                # auto-regenerate-on-entry only ever printed "command not
-                # found"; it is removed rather than left erroring on every
-                # shell entry.)
+                # deliberately on a dependency bump by running `update-zon`
+                # inside this dev shell (it wraps `zig build --fetch` + the
+                # pinned zig2nix `zon2lock` app; there is no plain `zig2nix`
+                # binary on PATH). Not auto-run on shell entry — a stale lock
+                # after a bump would otherwise need network the sandbox lacks.
 
                 echo "PolicyPress development environment"
                 echo ""
@@ -844,6 +855,7 @@
                 echo "  nix run .#release      - cross-compile release builds"
                 echo "  nix flake check        - run formatting check + tests"
                 echo "  om ci                  - run full CI locally"
+                echo "  update-zon             - regenerate the zon lock after a dep bump"
               '';
             };
           };

--- a/flake.nix
+++ b/flake.nix
@@ -165,7 +165,11 @@
             };
 
             runtimeDeps = with pkgs; [
-              typst
+              # typst with the mitex package vendored into its offline package
+              # cache, so `@preview/mitex` resolves in the hermetic build (opt-in
+              # policy math renders TeX via mitex). Keep the mitex version here in
+              # lock-step with the `#import "@preview/mitex:X"` line in src/typst.zig.
+              (typst.withPackages (p: [ p.mitex ]))
               zola
             ];
 

--- a/golden_test.zig
+++ b/golden_test.zig
@@ -38,6 +38,10 @@ test "golden: test_policy_render (plain)" {
     try checkGolden("test_policy_render.typ", "src/test/test_policy_render.md", .plain);
 }
 
+test "golden: test_policy_math (plain)" {
+    try checkGolden("test_policy_math.typ", "src/test/test_policy_math.md", .plain);
+}
+
 fn checkReportGolden(comptime baseline: []const u8, kind: anytype) !void {
     const expected = @embedFile("tests/golden/" ++ baseline);
     const actual = try golden.renderReportFixture(std.testing.io, std.testing.allocator, kind);

--- a/src/config.zig
+++ b/src/config.zig
@@ -476,7 +476,8 @@ fn firstRawHtmlInInlines(inlines: []const zigmark.AST.Inline) ?RawHtmlRef {
         .link => |l| if (firstRawHtmlInInlines(l.children.items)) |f| return f,
         // Leaf inlines. `autolink` is deliberately treated as non-HTML:
         // `<user@host>` / `<https://…>` are autolinks, which the PDF renders.
-        .text, .code_span, .image, .autolink, .footnote_reference, .hard_break, .soft_break => {},
+        // `math` carries a TeX string, never raw HTML.
+        .text, .code_span, .image, .autolink, .footnote_reference, .hard_break, .soft_break, .math => {},
     };
     return null;
 }

--- a/src/test.zig
+++ b/src/test.zig
@@ -241,12 +241,13 @@ test "typst source: opt-in math emits mitex import and calls" {
     defer rendered.deinit(alloc);
 
     // The consumer preamble must import mitex (zigmark emits `#mi`/`#mitex`
-    // calls but never the import) and set the equation alt-text fallback that
-    // typst's PDF/UA-1 mode requires.
+    // calls but never the import).
     try tst.expect(std.mem.indexOf(u8, rendered.source, "#import \"@preview/mitex:0.2.7\": mi, mitex") != null);
-    try tst.expect(std.mem.indexOf(u8, rendered.source, "#set math.equation(alt:") != null);
-    // Inline `$…$` → `#mi(`, display `$$…$$` → `#mitex(`.
-    try tst.expect(std.mem.indexOf(u8, rendered.source, "#mi(") != null);
+    // zigmark v0.10.0 carries per-equation alt text (the TeX source), which
+    // typst's PDF/UA-1 mode requires — no document-wide fallback needed.
+    try tst.expect(std.mem.indexOf(u8, rendered.source, "#set math.equation(alt:") == null);
+    // Inline `$…$` → `#mi("…", alt: "…")`, display `$$…$$` → `#mitex("…", alt: "…")`.
+    try tst.expect(std.mem.indexOf(u8, rendered.source, "#mi(\"R > 15\", alt: \"R > 15\")") != null);
     try tst.expect(std.mem.indexOf(u8, rendered.source, "#mitex(") != null);
     // #136: a Markdown image's alt text becomes the Typst `image(alt:)` arg.
     try tst.expect(std.mem.indexOf(u8, rendered.source, "alt: \"Risk scoring matrix\"") != null);

--- a/src/test.zig
+++ b/src/test.zig
@@ -250,6 +250,8 @@ test "typst source: opt-in math emits mitex import and calls" {
     try tst.expect(std.mem.indexOf(u8, rendered.source, "#mitex(") != null);
     // #136: a Markdown image's alt text becomes the Typst `image(alt:)` arg.
     try tst.expect(std.mem.indexOf(u8, rendered.source, "alt: \"Risk scoring matrix\"") != null);
+    // Root-absolute image path is rewritten to its static/ location for --root.
+    try tst.expect(std.mem.indexOf(u8, rendered.source, "image(\"/static/diagram.png\"") != null);
 }
 
 test "typst source: math stays off without extra.math opt-in" {

--- a/src/test.zig
+++ b/src/test.zig
@@ -232,6 +232,38 @@ test "typst source: mermaid renders as inline svg via pozeiden" {
     try tst.expect(std.mem.indexOf(u8, rendered.source, "```mermaid") == null);
 }
 
+test "typst source: opt-in math emits mitex import and calls" {
+    const alloc = tst.allocator;
+    var conf = try config.load(io, alloc, TestConfig);
+    defer conf.deinit(alloc);
+
+    var rendered = try typst.render(io, alloc, conf, "src/test/test_policy_math.md");
+    defer rendered.deinit(alloc);
+
+    // The consumer preamble must import mitex (zigmark emits `#mi`/`#mitex`
+    // calls but never the import) and set the equation alt-text fallback that
+    // typst's PDF/UA-1 mode requires.
+    try tst.expect(std.mem.indexOf(u8, rendered.source, "#import \"@preview/mitex:0.2.7\": mi, mitex") != null);
+    try tst.expect(std.mem.indexOf(u8, rendered.source, "#set math.equation(alt:") != null);
+    // Inline `$…$` → `#mi(`, display `$$…$$` → `#mitex(`.
+    try tst.expect(std.mem.indexOf(u8, rendered.source, "#mi(") != null);
+    try tst.expect(std.mem.indexOf(u8, rendered.source, "#mitex(") != null);
+    // #136: a Markdown image's alt text becomes the Typst `image(alt:)` arg.
+    try tst.expect(std.mem.indexOf(u8, rendered.source, "alt: \"Risk scoring matrix\"") != null);
+}
+
+test "typst source: math stays off without extra.math opt-in" {
+    const alloc = tst.allocator;
+    var conf = try config.load(io, alloc, TestConfig);
+    defer conf.deinit(alloc);
+
+    // test_policy_render.md does not set extra.math, so no mitex import appears
+    // even though math would be inert; guards the opt-in gate against drift.
+    var rendered = try typst.render(io, alloc, conf, "src/test/test_policy_render.md");
+    defer rendered.deinit(alloc);
+    try tst.expect(std.mem.indexOf(u8, rendered.source, "@preview/mitex") == null);
+}
+
 test "typst source: redaction produces solid bars" {
     const alloc = tst.allocator;
     var conf = try config.load(io, alloc, TestConfig);
@@ -504,6 +536,35 @@ test "missing frontmatter: no revisions → NoRevisionsInFrontMatter" {
         error.NoRevisionsInFrontMatter,
         utils.get_metadata(alloc, &arr, .{ .redact = false, .is_draft = false }),
     );
+}
+
+test "frontmatter: trailing YAML comment after a scalar parses (zig-yaml 0.3.1)" {
+    // Regression for the sc2in/zig-yaml fix bundled in zigmark v0.9.0: a
+    // trailing `# comment` after a plain scalar in a block sequence entry
+    // previously failed the whole document with ParseFailure. A policy author
+    // annotating a revision date with a comment must not break the build.
+    const alloc = tst.allocator;
+    const md = makePolicyMd(
+        \\title: "Test Policy"
+        \\description: "Test"
+        \\extra:
+        \\  last_reviewed: "2024-01-01"  # last audit
+        \\  major_revisions:
+        \\  - date: "2024-01-01"  # when
+        \\    description: "Initial"
+        \\    revised_by: "Author"
+        \\    approved_by: "Approver"
+        \\    version: "1.0"
+        ,
+    );
+    var arr = Array(u8).empty;
+    defer arr.deinit(alloc);
+    try arr.appendSlice(alloc, md);
+    // Parses cleanly (no ParseFailure) and the commented values are intact.
+    var fm = try utils.get_metadata(alloc, &arr, .{ .redact = false, .is_draft = false });
+    defer fm.deinit(alloc);
+    try tst.expectEqualStrings("2024-01-01", fm.last_reviewed);
+    try tst.expectEqualStrings("1.0", fm.most_recent_version);
 }
 
 test "missing frontmatter: description → NoDescriptionInFrontMatter" {

--- a/src/test/test_policy_math.md
+++ b/src/test/test_policy_math.md
@@ -1,0 +1,38 @@
+---
+title: "Math Test Policy"
+description: "Fixture exercising opt-in TeX math and Markdown image alt text"
+date: 2024-11-13
+weight: 10
+taxonomies:
+  TSC2017:
+    - CC2.1
+  SCF:
+    - HRS-05
+extra:
+  owner: SC2
+  last_reviewed: 2025-02-24
+  math: true
+  major_revisions:
+    - date: 2025-06-24
+      description: Initial version.
+      revised_by: Ben Craton
+      approved_by: Ben Craton
+      version: "1.0"
+---
+
+## Purpose
+
+This policy verifies that opt-in TeX math renders in the PDF via mitex.
+
+## Risk formula
+
+The composite risk score is $Risk = Threat \times Vulnerability$, evaluated per
+asset. The full model is:
+
+$$Risk = Threat \times Vulnerability \times Impact$$
+
+Any residual score above $R > 15$ requires documented mitigation.
+
+## Reference diagram
+
+![Risk scoring matrix](/static/diagram.png)

--- a/src/test/test_policy_math.md
+++ b/src/test/test_policy_math.md
@@ -35,4 +35,4 @@ Any residual score above $R > 15$ requires documented mitigation.
 
 ## Reference diagram
 
-![Risk scoring matrix](/static/diagram.png)
+![Risk scoring matrix](/diagram.png)

--- a/src/typst.zig
+++ b/src/typst.zig
@@ -245,6 +245,10 @@ pub fn render(
 
     try u.replace_org(alloc, &contents, config.org);
     try u.replace_zola_at(alloc, &contents, config.base_url);
+    // Root-absolute image paths (`/x`, Zola-served from `static/`) must point at
+    // `/static/x` for the Typst `--root`, or the image 404s in the PDF. Runs
+    // after replace_zola_at so `@/…` links (now full URLs) are already skipped.
+    try u.rewrite_image_paths(alloc, &contents);
     try u.replace_admonitions(alloc, &contents);
     try u.replace_mermaid(alloc, &contents);
     // `u.redact` masks redacted spans with solid `█` bars directly (only the

--- a/src/typst.zig
+++ b/src/typst.zig
@@ -270,16 +270,10 @@ pub fn render(
     // Opt-in TeX math: a per-policy `extra.math: true` enables it, mirroring the
     // web KaTeX gate (templates/macros/math.html reads `page.extra.math`). Off by
     // default, so zigmark's output — and every existing golden — is unchanged.
-    // In YAML front matter the zigmark parser types an unquoted `true` as a
-    // string (only TOML yields a native bool), so accept either representation.
-    const math_on: bool = blk: {
-        if (raw_fm.get("extra.math")) |v| break :blk switch (v) {
-            .bool => |b| b,
-            .string => |s| std.mem.eql(u8, s, "true"),
-            else => false,
-        };
-        break :blk false;
-    };
+    const math_on: bool = if (raw_fm.get("extra.math")) |v|
+        v == .bool and v.bool
+    else
+        false;
 
     var parser = zigmark.Parser.init();
     parser.math = math_on;
@@ -516,19 +510,15 @@ fn writePreamble(writer: anytype, opts: DocOpts) !void {
         .footer_center = opts.footer_center,
     });
 
-    // Opt-in TeX math. zigmark's Typst renderer emits `#mi(…)`/`#mitex(…)` but
-    // deliberately does not import mitex, so the consumer's preamble must. We
-    // also set a document-wide equation alt-text fallback: typst's PDF/UA-1 mode
-    // hard-fails on any equation lacking alt text and zigmark emits none — this
-    // mirrors the `#set image(alt:)` fallback in writeDocSetup. Emitted here, not
-    // in writeDocSetup, so the report PDFs (which share writeDocSetup, have no
-    // math) stay mitex-free. The mitex version is pinned in lock-step with
-    // flake.nix's `typst.withPackages [ mitex ]` (offline package cache).
+    // Opt-in TeX math. zigmark's Typst renderer emits `#mi(…, alt: …)` /
+    // `#mitex(…, alt: …)` (per-equation alt text, which typst's PDF/UA-1 mode
+    // requires) but deliberately does not import mitex, so the consumer's
+    // preamble must. Emitted here, not in writeDocSetup, so the report PDFs
+    // (which share writeDocSetup and have no math) stay mitex-free. The mitex
+    // version is pinned in lock-step with flake.nix's `typst.withPackages
+    // [ mitex ]` (offline package cache).
     if (opts.math) {
-        try writer.writeAll(
-            "#import \"@preview/mitex:0.2.7\": mi, mitex\n" ++
-                "#set math.equation(alt: \"Mathematical formula\")\n\n",
-        );
+        try writer.writeAll("#import \"@preview/mitex:0.2.7\": mi, mitex\n\n");
     }
     try writeTitlePage(writer, .{
         .title = opts.title,

--- a/src/typst.zig
+++ b/src/typst.zig
@@ -102,6 +102,10 @@ const DocOpts = struct {
     /// to the title page so a printed redacted PDF is self-identifying, not just
     /// distinguishable by filename.
     redact: bool = false,
+    /// Whether the body contains TeX math (opt-in via per-policy `extra.math`,
+    /// and the doc actually has math). When true the preamble imports mitex and
+    /// sets a document-wide equation alt-text fallback for PDF/UA-1.
+    math: bool = false,
 };
 
 /// A fully rendered policy: the Typst source and the sanitised PDF filename.
@@ -259,10 +263,29 @@ pub fn render(
 
     // ── 4. Parse Markdown → AST ──────────────────────────────────────────────
 
+    // Opt-in TeX math: a per-policy `extra.math: true` enables it, mirroring the
+    // web KaTeX gate (templates/macros/math.html reads `page.extra.math`). Off by
+    // default, so zigmark's output — and every existing golden — is unchanged.
+    // In YAML front matter the zigmark parser types an unquoted `true` as a
+    // string (only TOML yields a native bool), so accept either representation.
+    const math_on: bool = blk: {
+        if (raw_fm.get("extra.math")) |v| break :blk switch (v) {
+            .bool => |b| b,
+            .string => |s| std.mem.eql(u8, s, "true"),
+            else => false,
+        };
+        break :blk false;
+    };
+
     var parser = zigmark.Parser.init();
+    parser.math = math_on;
     defer parser.deinit(alloc);
     var doc = try parser.parseMarkdown(alloc, contents.items);
     defer doc.deinit(alloc);
+
+    // Only pull in mitex when math is both enabled and actually present, so a
+    // policy that opts in but writes no `$…$` still produces a mitex-free PDF.
+    const has_math = math_on and zigmark.docHasMath(&doc);
 
     // ── 5. Build Typst source ────────────────────────────────────────────────
 
@@ -329,6 +352,7 @@ pub fn render(
         .version = fm.most_recent_version,
         .last_reviewed = fm.last_reviewed,
         .redact = config.redact,
+        .math = has_math,
     });
     try zigmark.renderTypstWithMermaid(alloc, &aw.writer, doc, &renderMermaid);
     try writeVersionHistory(&aw.writer, &raw_fm);
@@ -487,6 +511,21 @@ fn writePreamble(writer: anytype, opts: DocOpts) !void {
         .footer_left = opts.footer_left,
         .footer_center = opts.footer_center,
     });
+
+    // Opt-in TeX math. zigmark's Typst renderer emits `#mi(…)`/`#mitex(…)` but
+    // deliberately does not import mitex, so the consumer's preamble must. We
+    // also set a document-wide equation alt-text fallback: typst's PDF/UA-1 mode
+    // hard-fails on any equation lacking alt text and zigmark emits none — this
+    // mirrors the `#set image(alt:)` fallback in writeDocSetup. Emitted here, not
+    // in writeDocSetup, so the report PDFs (which share writeDocSetup, have no
+    // math) stay mitex-free. The mitex version is pinned in lock-step with
+    // flake.nix's `typst.withPackages [ mitex ]` (offline package cache).
+    if (opts.math) {
+        try writer.writeAll(
+            "#import \"@preview/mitex:0.2.7\": mi, mitex\n" ++
+                "#set math.equation(alt: \"Mathematical formula\")\n\n",
+        );
+    }
     try writeTitlePage(writer, .{
         .title = opts.title,
         .version = opts.version,

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -326,6 +326,81 @@ test "replace_zola_at" {
     try tst.expectEqualStrings(expected, arr.items);
 }
 
+/// For the PDF pipeline only: rewrite a Markdown image whose destination is a
+/// site-root-absolute path (`![alt](/x)`) to its on-disk location under
+/// `static/` (`![alt](/static/x)`).
+///
+/// Zola serves `static/x` at the web root `/x`, so that is how authors
+/// reference images. But the Typst compiler resolves paths against the project
+/// root (`--root`), where the file actually lives under `static/`. Without this
+/// rewrite an authored image renders on the website but 404s in the PDF.
+///
+/// External URLs (`http://`, `https://`), protocol-relative `//…`, data URIs,
+/// and paths already under `/static/` are left untouched. Deterministic — no
+/// filesystem access, so a genuinely missing image surfaces as a clear Typst
+/// compile error rather than being silently dropped.
+pub fn rewrite_image_paths(alloc: Allocator, txt: *Array(u8)) !void {
+    const img: mvzr.Regex = mvzr.compile("!\\[.*?\\]\\(/.*?\\)").?;
+    if (!img.isMatch(txt.items)) return;
+
+    var out = Array(u8).empty;
+    errdefer out.deinit(alloc);
+
+    var last: usize = 0;
+    var iter = img.iterator(txt.items);
+    while (iter.next()) |match| {
+        try out.appendSlice(alloc, txt.items[last..match.start]);
+
+        // match.slice is "![alt](/dest)"; split at the final "](".
+        const open = std.mem.lastIndexOf(u8, match.slice, "](").?;
+        const prefix = match.slice[0 .. open + 2]; // "![alt]("
+        const dest = match.slice[open + 2 .. match.slice.len - 1]; // "/dest"
+
+        try out.appendSlice(alloc, prefix);
+        if (std.mem.startsWith(u8, dest, "/") and
+            !std.mem.startsWith(u8, dest, "//") and
+            !std.mem.startsWith(u8, dest, "/static/"))
+        {
+            try out.appendSlice(alloc, "/static");
+        }
+        try out.appendSlice(alloc, dest);
+        try out.appendSlice(alloc, ")");
+
+        last = match.start + match.slice.len;
+    }
+    try out.appendSlice(alloc, txt.items[last..]);
+
+    txt.deinit(alloc);
+    txt.* = out;
+}
+
+test "rewrite_image_paths" {
+    const allocator = tst.allocator;
+
+    var arr = Array(u8).empty;
+    defer arr.deinit(allocator);
+    try arr.appendSlice(allocator,
+        \\![a diagram](/diagram.png)
+        \\![nested](/img/flow.svg)
+        \\![already static](/static/logo.png)
+        \\![external](https://example.com/x.png)
+        \\![protocol relative](//cdn/x.png)
+        \\a [normal link](/some-page) stays
+    );
+
+    try rewrite_image_paths(allocator, &arr);
+
+    const expected =
+        \\![a diagram](/static/diagram.png)
+        \\![nested](/static/img/flow.svg)
+        \\![already static](/static/logo.png)
+        \\![external](https://example.com/x.png)
+        \\![protocol relative](//cdn/x.png)
+        \\a [normal link](/some-page) stays
+    ;
+    try tst.expectEqualStrings(expected, arr.items);
+}
+
 /// Finds and replaces custom Mermaid code blocks in the markdown with a standardized code block format.
 pub fn replace_mermaid(alloc: Allocator, txt: *Array(u8)) !void {
     const mermaid: mvzr.Regex = mvzr.compile("\\{%\\s*mermaid\\(\\)\\s*%\\}.+?\\{%\\s*end\\s*%\\}").?;

--- a/static/data-classification.svg
+++ b/static/data-classification.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 170" width="600" height="170" font-family="sans-serif">
+  <rect x="0" y="0" width="600" height="170" fill="#ffffff"/>
+  <text x="300" y="26" text-anchor="middle" font-size="17" font-weight="700" fill="#1a2733">Data Classification Tiers</text>
+
+  <!-- Public -->
+  <rect x="20" y="52" width="176" height="86" rx="8" fill="#e6f2fb" stroke="#0e90f3" stroke-width="1.5"/>
+  <text x="108" y="86" text-anchor="middle" font-size="15" font-weight="700" fill="#0b3a5b">Public</text>
+  <text x="108" y="110" text-anchor="middle" font-size="11" fill="#33475b">Standard controls</text>
+
+  <!-- Internal -->
+  <rect x="212" y="52" width="176" height="86" rx="8" fill="#0e90f3" stroke="#0b6fbf" stroke-width="1.5"/>
+  <text x="300" y="86" text-anchor="middle" font-size="15" font-weight="700" fill="#ffffff">Internal</text>
+  <text x="300" y="110" text-anchor="middle" font-size="11" fill="#eaf4fd">Access controls</text>
+
+  <!-- Confidential -->
+  <rect x="404" y="52" width="176" height="86" rx="8" fill="#0b3a5b" stroke="#082a43" stroke-width="1.5"/>
+  <text x="492" y="82" text-anchor="middle" font-size="15" font-weight="700" fill="#ffffff">Confidential</text>
+  <text x="492" y="104" text-anchor="middle" font-size="11" fill="#cfe2f2">Encryption +</text>
+  <text x="492" y="120" text-anchor="middle" font-size="11" fill="#cfe2f2">strict access</text>
+
+  <!-- increasing-protection arrow -->
+  <line x1="20" y1="153" x2="580" y2="153" stroke="#8aa0b2" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="20" y="167" font-size="10" fill="#5a6b7a">lower sensitivity</text>
+  <text x="580" y="167" text-anchor="end" font-size="10" fill="#5a6b7a">higher sensitivity</text>
+  <defs>
+    <marker id="arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#8aa0b2"/>
+    </marker>
+  </defs>
+</svg>

--- a/tests/golden/test_policy_math.typ
+++ b/tests/golden/test_policy_math.typ
@@ -1,0 +1,128 @@
+#set document(
+  title: "Math Test Policy",
+  author: "Star City Security Consulting",
+)
+
+#set image(alt: "Diagram")
+
+#set page(
+  paper: "us-letter",
+  margin: (x: 2.5cm, y: 2.5cm),
+  header: [
+    #set text(size: 9pt, fill: rgb("#777777"))
+    #grid(
+      columns: (1fr, 1fr, 1fr),
+      align: (left, center, right),
+      [Math Test Policy v1.0],
+      [],
+      [#image("/static/logo.png", height: 20pt)],
+    )
+  ],
+  footer: [
+    #set text(size: 9pt, fill: rgb("#777777"))
+    #grid(
+      columns: (1fr, 1fr, 1fr),
+      align: (left, center, right),
+      [Star City Security Consulting © 2026],
+      [Confidential],
+      [#context counter(page).display("1")],
+    )
+  ],
+)
+
+#set text(
+  font: "Source Sans 3",
+  size: 11pt,
+  lang: "en",
+)
+
+#show raw: set text(font: ("Source Code Pro", "DejaVu Sans Mono"))
+
+#show raw.where(block: true): it => block(
+  fill: rgb("#F7F7F7"),
+  inset: 10pt,
+  radius: 4pt,
+  width: 100%,
+  stroke: 0.5pt + rgb("#DDDDDD"),
+  it,
+)
+
+#show heading: it => {
+  set text(fill: rgb("#282828"))
+  it
+}
+
+#show link: set text(fill: rgb("#A50000"))
+
+#show figure.caption: it => {
+  set text(fill: rgb("#777777"), size: 9pt)
+  it
+}
+
+#set table(
+  fill: (_, row) => if row == 0 { rgb("#EEEEEE") } else if calc.odd(row) { white } else { rgb("#F7F7F7") },
+  stroke: rgb("#999999"),
+)
+
+#import "@preview/mitex:0.2.7": mi, mitex
+#set math.equation(alt: "Mathematical formula")
+
+// ── Title page ─────────────────────────────────────────────────────────
+#page(
+  margin: (x: 2.5cm, y: 2.5cm),
+  header: none,
+  footer: none,
+)[
+  #v(3cm)
+
+  #heading(level: 1, outlined: false)[#text(size: 36pt, weight: "bold")[Math Test Policy]]
+
+  #v(0.5cm)
+  #text(size: 18pt)[Version v1.0]
+
+  #v(1.5cm)
+  #line(length: 100%, stroke: 4pt + rgb("#0e90f3"))
+
+  #text(size: 18pt)[Star City Security Consulting]
+
+  #v(1fr)
+
+  #image("/static/logo.png", width: 6cm)
+
+  #text(size: 11pt)[Last Reviewed: 2025-02-24]
+]
+
+#outline(
+  title: "Contents",
+  depth: 3,
+)
+
+== Purpose
+This policy verifies that opt-in TeX math renders in the PDF via mitex.
+
+== Risk formula
+The composite risk score is #mi("Risk = Threat \\times Vulnerability"), evaluated per asset. The full model is:
+
+#mitex("Risk = Threat \\times Vulnerability \\times Impact")
+
+Any residual score above #mi("R > 15") requires documented mitigation.
+
+== Reference diagram
+#figure(image("/static/diagram.png", alt: "Risk scoring matrix"), caption: [Risk scoring matrix])
+
+
+#pagebreak()
+= Version History
+
+#table(
+  columns: (auto, auto, 1fr, auto, auto),
+  align: (center, center, left, center, center),
+  table.header(
+    [*Version*], [*Date*], [*Description*], [*Revised By*], [*Approved By*],
+  ),
+  [1.0],
+  [2025-06-24],
+  [Initial version.],
+  [Ben Craton],
+  [Ben Craton],
+)

--- a/tests/golden/test_policy_math.typ
+++ b/tests/golden/test_policy_math.typ
@@ -65,7 +65,6 @@
 )
 
 #import "@preview/mitex:0.2.7": mi, mitex
-#set math.equation(alt: "Mathematical formula")
 
 // ── Title page ─────────────────────────────────────────────────────────
 #page(
@@ -101,11 +100,11 @@
 This policy verifies that opt-in TeX math renders in the PDF via mitex.
 
 == Risk formula
-The composite risk score is #mi("Risk = Threat \\times Vulnerability"), evaluated per asset. The full model is:
+The composite risk score is #mi("Risk = Threat \\times Vulnerability", alt: "Risk = Threat \\times Vulnerability"), evaluated per asset. The full model is:
 
-#mitex("Risk = Threat \\times Vulnerability \\times Impact")
+#mitex("Risk = Threat \\times Vulnerability \\times Impact", alt: "Risk = Threat \\times Vulnerability \\times Impact")
 
-Any residual score above #mi("R > 15") requires documented mitigation.
+Any residual score above #mi("R > 15", alt: "R > 15") requires documented mitigation.
 
 == Reference diagram
 #figure(image("/static/diagram.png", alt: "Risk scoring matrix"), caption: [Risk scoring matrix])

--- a/tools/sbom.sh
+++ b/tools/sbom.sh
@@ -10,6 +10,10 @@
 #     zola), with the exact version of the binary on PATH (pinned by
 #     flake.lock). These are not linked into the binary but a CVE in either
 #     affects the output pipeline, so an SBOM consumer needs to see them.
+#   - typst-package: Typst universe packages vendored into typst's offline
+#     package cache and loaded at compile time (mitex, which renders TeX math).
+#     Runs inside typst and shapes the PDF output, so a CVE in it is in scope
+#     too; modelled as a dependency of typst in the graph.
 #
 # The build toolchain itself (zig, glibc, the JVM veraPDF pulls in, …) is
 # pinned by flake.lock and published on FlakeHub; a full build-environment
@@ -43,12 +47,20 @@ tool_version() {
 TYPST_VERSION="$(tool_version typst)"
 ZOLA_VERSION="$(tool_version zola)"
 
+# mitex has no CLI to query, but the `@preview/mitex:<version>` import in the
+# Typst preamble is the authority for which version is loaded — and CI's
+# pdf-accessibility gate compiles the demo's math, so a mismatch with the
+# vendored package fails the build. Read the version from there.
+MITEX_VERSION="$(sed -n 's/.*@preview\/mitex:\([0-9][0-9.]*\).*/\1/p' src/typst.zig | head -1)"
+MITEX_VERSION="${MITEX_VERSION:-unknown}"
+
 jq -n \
   --arg version "$VERSION" \
   --arg commit "$COMMIT" \
   --arg timestamp "$TIMESTAMP" \
   --arg typst "$TYPST_VERSION" \
   --arg zola "$ZOLA_VERSION" \
+  --arg mitex "$MITEX_VERSION" \
   --slurpfile lock "$LOCK" \
   '
   # Compiled-in Zig deps. A lock key looks like "name-1.2.3-<fingerprint>";
@@ -97,7 +109,26 @@ jq -n \
         ]
       });
 
-  (zig_components + tool_components) as $all
+  # Typst universe packages vendored into the offline typst cache and loaded at
+  # compile time (mitex renders TeX math). Depended on by typst, not the root.
+  def package_components:
+    [
+      {
+        type: "library",
+        "bom-ref": ("mitex@" + $mitex),
+        name: "mitex",
+        version: $mitex,
+        purl: ("pkg:generic/mitex@" + $mitex),
+        externalReferences: [ { type: "website", url: "https://typst.app/universe/package/mitex" } ],
+        properties: [
+          { name: "policypress:dependency-kind", value: "typst-package" },
+          { name: "typst:package-spec", value: ("@preview/mitex:" + $mitex) },
+          { name: "nixpkgs:pinned-by", value: "flake.lock" }
+        ]
+      }
+    ];
+
+  (zig_components + tool_components + package_components) as $all
   | ("policypress@" + $version) as $root
   | {
       bomFormat: "CycloneDX",
@@ -118,12 +149,15 @@ jq -n \
         },
         properties: [
           { name: "policypress:git-commit", value: $commit },
-          { name: "policypress:sbom-scope", value: "compiled-in-zig-deps + runtime-tools" }
+          { name: "policypress:sbom-scope", value: "compiled-in-zig-deps + runtime-tools + typst-packages" }
         ]
       },
       components: $all,
       dependencies: [
-        { ref: $root, dependsOn: ($all | map(.["bom-ref"])) }
+        # Root depends on the zig deps and the subprocess tools; mitex is a
+        # dependency of typst, not of policypress directly.
+        { ref: $root, dependsOn: (($all | map(.["bom-ref"])) - [("mitex@" + $mitex)]) },
+        { ref: ("typst@" + $typst), dependsOn: [ ("mitex@" + $mitex) ] }
       ]
     }
   '


### PR DESCRIPTION
## What

Closes the last non-license v2 launch blocker and bundles the freebies that
came with it.

- **TeX math in policy PDFs (#140).** Opt-in per policy via `extra.math: true`
  (the same flag that enables KaTeX on the site). `$…$`/`$$…$$` render through
  the Typst `mitex` package instead of appearing as literal dollar-text. Off by
  default → every non-math policy's PDF is byte-identical. `mitex` is vendored
  into the offline Typst build (`typst.withPackages`), so no network at build
  time.
- **Markdown image alt text in tagged PDFs (#136).** A Markdown image's alt
  text becomes the Typst `image(alt: …)` argument (via the zigmark v0.9.0
  upgrade), so images meet PDF/UA-1's alt-text requirement.
- **Authored images render in PDFs.** Root-absolute image paths (`![alt](/x)`,
  which Zola serves from `static/` at the web root) are rewritten to `/static/x`
  for the Typst `--root`, so an authored image resolves in the PDF as well as on
  the site. Demonstrated with a real SVG in the example policy.
- **zig-yaml robustness (free with the bump).** A trailing `# comment` after a
  front-matter value no longer breaks the build.
- **`update-zon` now works.** The dev-shell lock regenerator called a `zig2nix`
  binary that isn't on `PATH`; it now uses `zig build --fetch` + the pinned
  zig2nix `zon2lock` app and appends the trailing newline the pre-commit hook
  requires.

## Verification

`nix flake check` is green (fmt, pre-commit, test, test-release-safe,
redaction-leak, and **pdf-accessibility**). The demo's `Example_Security_Policy`
PDF — which carries both math and the new SVG — passes veraPDF UA-1, and its
text layer shows rendered math (`𝑅 > 15`), not escaped `$…$`. New fixture,
golden, and unit tests cover the math markup, the image alt-text, the image
path rewrite, and the trailing-comment regression.

## Follow-ups (do not block, but improve the stopgaps here)

- zigmark sc2in/zigmark#78 — emit `math.equation(alt: …)` so equations get
  per-equation alt text instead of this PR's document-wide
  `#set math.equation(alt: "Mathematical formula")` fallback.
- zigmark sc2in/zigmark#79 — type YAML front-matter scalars (bool/int) like
  TOML, so the `extra.math` gate can stop accepting both `.bool` and the string
  `"true"`.

Closes #140. Closes #136.
