### PR TITLE
chore: drop x86_64-darwin from supported systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ versioning; breaking changes to it bump the major version.
 
 ## [Unreleased]
 
+### Removed
+
+- **Dropped `x86_64-darwin` (Intel macOS) from the flake's supported systems**,
+  following nixpkgs retiring it as a supported platform. `nix build`,
+  `nix develop`, and `nix flake check` no longer evaluate for Intel-Mac hosts;
+  CI runs on `aarch64-darwin` (`macos-latest` is Apple Silicon). The
+  cross-compiled `x86_64-macos` release binary is unaffected — it is still
+  built and shipped, since it cross-compiles from any host.
+
 ## [1.6.0] - 2026-07-18
 
 ### Internal

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,6 @@
         systems = [
           "x86_64-linux"
           "aarch64-linux"
-          "x86_64-darwin"
           "aarch64-darwin"
         ];
 


### PR DESCRIPTION
## What

Follows nixpkgs in retiring **`x86_64-darwin` (Intel macOS)** as a supported platform. Removes it from the flake `systems` list in `flake.nix`.

After this, `nix build`, `nix develop`, and `nix flake check` evaluate for `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin` only. CI is unaffected — GitHub's `macos-latest` runner is already Apple Silicon (`aarch64-darwin`).

## Scope note

The cross-compiled **`x86_64-macos` release binary is intentionally kept** (flake.nix release targets, `.github/workflows/ci.yml`, `action.yml`) — it cross-compiles from any host, so Intel-Mac users still get a shipped artifact. This change only drops x86_64-darwin as a *Nix evaluation/build system*, matching nixpkgs.

## Verification

- `nix flake show` evaluates cleanly; outputs enumerate exactly `x86_64-linux`, `aarch64-linux`, `aarch64-darwin` (no `x86_64-darwin`).