### PR TITLE
feat: synthesized control-ID footnotes in policy PDFs (zigmark 0.11)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -146,6 +146,24 @@ pub fn build(b: *std.Build) !void {
     reports_mod.addImport("typst", typst_mod);
     reports_mod.addImport("praxis_join", praxis_join_mod);
 
+    // Control-ID join (src/controls.zig): binds the SCF catalog, the optional
+    // praxis join, and a zigmark Library of the non-draft policies so inline
+    // control footnotes resolve to title + spine status + covering policies.
+    // Imports `reports` (which imports `typst`), so `typst` must NOT import
+    // this module — the footnote resolver reaches typst.render() as a plain
+    // `zigmark.footnotes.Resolver` value instead.
+    const controls_mod = b.addModule("controls", .{
+        .root_source_file = b.path("src/controls.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    controls_mod.addImport("zigmark", zigmark_mod);
+    controls_mod.addImport("reports", reports_mod);
+    controls_mod.addImport("praxis_join", praxis_join_mod);
+    controls_mod.addImport("config", config_mod);
+    controls_mod.addImport("utils", utils_mod);
+    controls_mod.addImport("mvzr", mvzr.module("mvzr"));
+
     // Shared render helper for the golden Typst-markup snapshots (used by both
     // golden_test.zig and tools/golden_gen.zig).
     const golden_mod = b.addModule("golden", .{
@@ -156,6 +174,7 @@ pub fn build(b: *std.Build) !void {
     golden_mod.addImport("config", config_mod);
     golden_mod.addImport("typst", typst_mod);
     golden_mod.addImport("reports", reports_mod);
+    golden_mod.addImport("controls", controls_mod);
 
     const policypress_mod = b.addModule("policypress", .{
         .target = target,
@@ -175,6 +194,7 @@ pub fn build(b: *std.Build) !void {
     policypress_mod.addImport("reports", reports_mod);
     policypress_mod.addImport("utils", utils_mod);
     policypress_mod.addImport("praxis_join", praxis_join_mod);
+    policypress_mod.addImport("controls", controls_mod);
     // Build-time mermaid rendering for the site (src/diagrams.zig, `render-diagrams`).
     policypress_mod.addImport("pozeiden", pozeiden_mod);
     const policypress_exe = b.addExecutable(.{
@@ -214,6 +234,7 @@ pub fn build(b: *std.Build) !void {
         test_module.addImport("config", config_mod);
         test_module.addImport("reports", reports_mod);
         test_module.addImport("praxis_join", praxis_join_mod);
+        test_module.addImport("controls", controls_mod);
         test_module.addImport("mvzr", mvzr.module("mvzr"));
         // src/diagrams.zig (imported by src/test.zig) renders mermaid via pozeiden.
         test_module.addImport("pozeiden", pozeiden_mod);
@@ -286,6 +307,10 @@ pub fn build(b: *std.Build) !void {
             .{ .name = "test_policy_draft.typ", .fixture = "src/test/test_policy.md", .flag = "--draft" },
             .{ .name = "test_policy_render.typ", .fixture = "src/test/test_policy_render.md", .flag = null },
             .{ .name = "test_policy_math.typ", .fixture = "src/test/test_policy_math.md", .flag = null },
+            // Control-footnote fixture: rendered with a fixture-backed ControlJoin
+            // context (`--controls`), so it shows native `#footnote[…]` with the
+            // resolved title / spine / covering-policy text.
+            .{ .name = "test_policy_controls.typ", .fixture = "--controls", .flag = null },
             .{ .name = "report_scf.typ", .fixture = "--report", .flag = "scf" },
             .{ .name = "report_soc2.typ", .fixture = "--report", .flag = "soc2" },
             .{ .name = "report_review.typ", .fixture = "--report", .flag = "review" },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -42,8 +42,8 @@
         // Switch to git+https URLs with hashes before publishing to FlakeHub.
         // .zetta = .{ .path = "../zetta" },
         .zigmark = .{
-            .url = "git+https://github.com/sc2in/zigmark?ref=v0.10.0#23d12b74dfe586c36f7a7cfd5350719c067cc2a6",
-            .hash = "zigmark-0.10.0-cwOiyOMRCwDf1Z62LEuDj6DCDL1M-vzAFdh969E6Rpl_",
+            .url = "git+https://github.com/sc2in/zigmark?ref=v0.11.0#63f68d4dd759836e35900b75a140a35ed7ab2223",
+            .hash = "zigmark-0.11.0-cwOiyGavCwD_RfjSI5UU-xGwQzgKbfnFv3Gjd454Ypqx",
         },
         .tomlz = .{
             .url = "git+https://github.com/sc2in/tomlz.git#ecd64e239768b573ec58286d0db1842991433e99",

--- a/build.zig.zon2json-lock
+++ b/build.zig.zon2json-lock
@@ -1,8 +1,8 @@
 {
-  "zigmark-0.10.0-cwOiyOMRCwDf1Z62LEuDj6DCDL1M-vzAFdh969E6Rpl_": {
+  "zigmark-0.11.0-cwOiyGavCwD_RfjSI5UU-xGwQzgKbfnFv3Gjd454Ypqx": {
     "name": "zigmark",
-    "url": "git+https://github.com/sc2in/zigmark?ref=v0.10.0#23d12b74dfe586c36f7a7cfd5350719c067cc2a6",
-    "hash": "sha256-pOMqX6x9EAfu8JyoWH6L4j26wtBX+86n6qjRn8P2MI0="
+    "url": "git+https://github.com/sc2in/zigmark?ref=v0.11.0#63f68d4dd759836e35900b75a140a35ed7ab2223",
+    "hash": "sha256-syIAWFl/bpBF0UnmjZ/h/KRH/2eJuU/hH+RxHMWzi7o="
   },
   "tomlz-0.3.0-H2E6w3VKAgCSZQFKG-VugLEn3cjOWshGqwGzAVABNm--": {
     "name": "tomlz",
@@ -44,10 +44,10 @@
     "url": "git+https://github.com/mnemnion/mvzr?ref=v0.3.10#dd0e1bd2d6b10f9650317b30baef7ab7bc9dd9ec",
     "hash": "sha256-hUGdJPjC1PAm6zWL9eAE7A+wAfzf6Q7uSutT2Xe7EMU="
   },
-  "zig_yaml-0.3.1-C1161s2zAgBOYGjCQB3uWdAadPevfdNiTaffefbhAhBq": {
+  "zig_yaml-0.3.2-C1161q3CAgCEpqWl_MKjkQpPZmos4DHBJewpb58XMcAL": {
     "name": "yaml",
-    "url": "git+https://github.com/sc2in/zig-yaml#7c60d9cd6ae596c8247ac74b5b8e32c329e7c1d0",
-    "hash": "sha256-JAYq7B7gXd4+c60KXZ9b5IuaKLY7x7Bn9TNynyx4kog="
+    "url": "git+https://github.com/sc2in/zig-yaml#3dc3441ee1f9a42565881a8f846f529fd8564bff",
+    "hash": "sha256-kILMfi0bF69Mm7MOZZ7+DeJ+iMdOkAfGd0mR7LXK3ns="
   },
   "mvzr-0.3.9-ZSOky6t2AQCA7efmm5EYbPb5sOdbXa4EFsUgYbQ6hZv9": {
     "name": "mvzr",

--- a/golden_test.zig
+++ b/golden_test.zig
@@ -42,6 +42,19 @@ test "golden: test_policy_math (plain)" {
     try checkGolden("test_policy_math.typ", "src/test/test_policy_math.md", .plain);
 }
 
+test "golden: control footnotes (fixture-backed ControlJoin)" {
+    const expected = @embedFile("tests/golden/test_policy_controls.typ");
+    const actual = try golden.renderControlFixture(std.testing.io, std.testing.allocator);
+    defer std.testing.allocator.free(actual);
+    std.testing.expectEqualStrings(expected, actual) catch |err| {
+        std.debug.print(
+            "\ngolden mismatch for test_policy_controls.typ — if the change is intentional, run `zig build update-golden` and review the diff.\n",
+            .{},
+        );
+        return err;
+    };
+}
+
 fn checkReportGolden(comptime baseline: []const u8, kind: anytype) !void {
     const expected = @embedFile("tests/golden/" ++ baseline);
     const actual = try golden.renderReportFixture(std.testing.io, std.testing.allocator, kind);

--- a/src/controls.zig
+++ b/src/controls.zig
@@ -1,0 +1,393 @@
+//! Copyright © 2025 [Star City Security Consulting, LLC (SC2)](https://sc2.in)
+//! SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//!
+//! Control-ID join for policy PDFs (#127 / #164).
+//!
+//! Binds three read-only data sources so that inline control references become
+//! footnotes carrying auditable context:
+//!
+//!   * the SCF control catalog (`data/scf.json`, via `control_report.zig`) — the
+//!     control title;
+//!   * the optional praxis join (`data/praxis-join.json`) — whether the control
+//!     is in praxis's actively-governed spine; and
+//!   * a `zigmark.Library` of the non-draft policies — the render-time reverse
+//!     lookup (control id → covering policy titles) that exists nowhere else.
+//!
+//! `ControlJoin` produces a `zigmark.footnotes.Resolver`: given a control label
+//! like `IAC-01`, it returns the Markdown definition body that
+//! `zigmark.footnotes.resolve` synthesises into the AST, which the Typst
+//! renderer then expands to a native `#footnote[…]`. Every clause degrades: a
+//! missing catalog drops the title, a missing join drops the praxis clause, no
+//! covering policy drops that clause — the id alone is always a valid footnote.
+//!
+//! `ControlJoin` is additive: it never touches `control_report.zig`'s
+//! `coverage()`, whose draft-exclusion / dedup / corrected-numerator logic stays
+//! canonical. After construction it is read-only, so a single instance is shared
+//! (by resolver value) across the concurrent per-policy compile tasks.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const tst = std.testing;
+
+const zigmark = @import("zigmark");
+const reports = @import("reports");
+const praxis_join = @import("praxis_join");
+const Config = @import("config").Config;
+const u = @import("utils");
+const mvzr = @import("mvzr");
+
+const ctrllog = std.log.scoped(.controls);
+
+/// The one control-id shape the whole toolchain agrees on:
+/// `^[A-Z]{2,5}-[0-9]{2}(\.[0-9]+)*$` (e.g. `IAC-01`, `HRS-05.1`, `IAC-21.5`).
+/// Implemented by hand rather than via a regex so it can anchor exactly and be
+/// reused for both validation and dangling-reference filtering without pulling
+/// mvzr anchoring semantics into the hot path.
+pub fn isControlId(s: []const u8) bool {
+    var i: usize = 0;
+    var letters: usize = 0;
+    while (i < s.len and s[i] >= 'A' and s[i] <= 'Z') : (i += 1) letters += 1;
+    if (letters < 2 or letters > 5) return false;
+    if (i >= s.len or s[i] != '-') return false;
+    i += 1;
+    // Exactly two digits.
+    if (i + 2 > s.len or !isDigit(s[i]) or !isDigit(s[i + 1])) return false;
+    i += 2;
+    // Zero or more `.<digits>` sub-control segments.
+    while (i < s.len) {
+        if (s[i] != '.') return false;
+        i += 1;
+        var digits: usize = 0;
+        while (i < s.len and isDigit(s[i])) : (i += 1) digits += 1;
+        if (digits == 0) return false;
+    }
+    return i == s.len;
+}
+
+fn isDigit(c: u8) bool {
+    return c >= '0' and c <= '9';
+}
+
+/// The more severe of two issue kinds (Config.IssueKind is ordered
+/// none < advisory < critical). Mirrors config.zig's private `maxKind`.
+fn maxKind(a: Config.IssueKind, b: Config.IssueKind) Config.IssueKind {
+    return if (@intFromEnum(a) >= @intFromEnum(b)) a else b;
+}
+
+pub const ControlJoin = struct {
+    /// SCF catalog instance (`control_report.zig`), or null when `data/scf.json`
+    /// is absent — the resolver then omits the title clause and validation skips
+    /// the unknown-id check.
+    catalog: ?reports,
+    /// praxis spine membership, or null when no join file is configured.
+    join: ?praxis_join.PraxisJoin,
+    /// The non-draft policies, queried for covering-policy titles.
+    library: zigmark.Library,
+
+    /// Build a `ControlJoin`.
+    ///
+    /// `catalog_path` / `join_path` are optional; `policy_paths` are the
+    /// non-draft policy files (resolved from the process working directory) fed
+    /// into the library one at a time (never `addFromDir`, which would pull in
+    /// drafts and `_index.md`).
+    ///
+    /// A missing/unreadable catalog degrades to `null` (footnotes lose the title
+    /// clause but stay valid). A configured-but-unloadable praxis join is a hard
+    /// error — silently dropping coverage data would be worse than failing.
+    pub fn init(
+        io: std.Io,
+        alloc: Allocator,
+        catalog_path: ?[]const u8,
+        join_path: ?[]const u8,
+        policy_paths: []const []const u8,
+    ) !ControlJoin {
+        var catalog: ?reports = null;
+        errdefer if (catalog) |*c| c.deinit();
+        if (catalog_path) |cp| {
+            catalog = reports.init(io, alloc, cp) catch |err| blk: {
+                ctrllog.info(
+                    "control catalog '{s}' unavailable ({s}); footnotes will omit control titles",
+                    .{ cp, @errorName(err) },
+                );
+                break :blk null;
+            };
+        }
+
+        var join: ?praxis_join.PraxisJoin = null;
+        errdefer if (join) |*j| j.deinit();
+        if (join_path) |jp| {
+            join = try praxis_join.PraxisJoin.load(io, alloc, jp);
+            // A configured catalog and join built from different SCF versions is a
+            // maintenance smell: spine ids the local catalog does not know cannot
+            // be titled. Advisory, so builds still pass (SCF-version skew is the
+            // author's to reconcile, not a hard failure).
+            if (catalog) |*c| {
+                for (join.?.ids) |id| {
+                    if (!c.map.contains(id)) {
+                        ctrllog.warn(
+                            "praxis spine id '{s}' is not in the local control catalog (SCF version skew)",
+                            .{id},
+                        );
+                    }
+                }
+            }
+        }
+
+        var library = zigmark.Library.init(alloc);
+        errdefer library.deinit();
+        for (policy_paths) |path| {
+            const src = std.Io.Dir.cwd().readFileAlloc(io, path, alloc, .limited(u.max_policy_bytes)) catch |err| {
+                ctrllog.warn("could not read policy '{s}' for the control library: {s}", .{ path, @errorName(err) });
+                continue;
+            };
+            defer alloc.free(src);
+            library.add(src, path) catch |err| {
+                ctrllog.warn("could not index policy '{s}' for the control library: {s}", .{ path, @errorName(err) });
+                continue;
+            };
+        }
+
+        return .{ .catalog = catalog, .join = join, .library = library };
+    }
+
+    pub fn deinit(self: *ControlJoin) void {
+        if (self.catalog) |*c| c.deinit();
+        if (self.join) |*j| j.deinit();
+        self.library.deinit();
+    }
+
+    /// A `zigmark.footnotes.Resolver` bound to this join. The returned resolver
+    /// borrows `self`; it must not outlive the `ControlJoin`.
+    pub fn resolver(self: *const ControlJoin) zigmark.footnotes.Resolver {
+        return .{ .ctx = @constCast(self), .resolveFn = resolveThunk };
+    }
+
+    fn resolveThunk(ctx: ?*anyopaque, alloc: Allocator, label: []const u8) anyerror!?[]const u8 {
+        const self: *const ControlJoin = @ptrCast(@alignCast(ctx.?));
+        return self.resolveFootnote(alloc, label);
+    }
+
+    /// Markdown definition body for a control footnote, or null when `label` is
+    /// not a control id (so a genuinely unknown footnote reference stays
+    /// dangling for validation to catch). Shape:
+    ///
+    ///   `IAC-01 — <title>. praxis: in control spine. Covered by: A, B.`
+    ///
+    /// with any clause omitted when its data source is absent. Caller owns the
+    /// returned slice (zigmark frees it, per the resolver contract).
+    pub fn resolveFootnote(self: *const ControlJoin, alloc: Allocator, label: []const u8) !?[]const u8 {
+        if (!isControlId(label)) return null;
+
+        var aw: std.Io.Writer.Allocating = .init(alloc);
+        defer aw.deinit();
+
+        // First sentence: the id and, when the catalog knows it, its title.
+        try aw.writer.writeAll(label);
+        if (self.catalog) |*cat| {
+            if (cat.map.get(label)) |ctrl| {
+                try aw.writer.print(" \u{2014} {s}", .{std.mem.trim(u8, ctrl.control, " ")});
+            }
+        }
+        try aw.writer.writeByte('.');
+
+        // praxis spine clause (only when a join is configured).
+        if (self.join) |*j| {
+            try aw.writer.print(" praxis: {s}.", .{
+                if (j.contains(label)) "in control spine" else "not in control spine",
+            });
+        }
+
+        // Covering-policy clause (only when ≥1 non-draft policy tags the control).
+        const covering = try self.coveringPolicies(alloc, label);
+        defer alloc.free(covering);
+        if (covering.len > 0) {
+            try aw.writer.writeAll(" Covered by: ");
+            for (covering, 0..) |title, i| {
+                if (i > 0) try aw.writer.writeAll(", ");
+                try aw.writer.writeAll(title);
+            }
+            try aw.writer.writeByte('.');
+        }
+
+        return try aw.toOwnedSlice();
+    }
+
+    /// Sorted, deduplicated titles of the non-draft policies whose
+    /// `taxonomies.SCF` lists `label`. The returned slice is owned by the caller
+    /// (`alloc.free`); its elements borrow from the library's frontmatter, which
+    /// lives for the whole build.
+    fn coveringPolicies(self: *const ControlJoin, alloc: Allocator, label: []const u8) ![]const []const u8 {
+        const q = try std.fmt.allocPrint(alloc, "taxonomies.SCF={s}", .{label});
+        defer alloc.free(q);
+
+        const results = (try self.library.query(alloc, q)) orelse return &.{};
+        defer alloc.free(results);
+
+        var titles = std.ArrayList([]const u8).empty;
+        errdefer titles.deinit(alloc);
+        for (results) |r| {
+            const fm = r.entry.frontmatter orelse continue;
+            const title_v = fm.get("title") orelse continue;
+            if (title_v != .string) continue;
+            const title = title_v.string;
+            var seen = false;
+            for (titles.items) |existing| {
+                if (std.mem.eql(u8, existing, title)) {
+                    seen = true;
+                    break;
+                }
+            }
+            if (!seen) try titles.append(alloc, title);
+        }
+        std.mem.sort([]const u8, titles.items, {}, lessThanStr);
+        return titles.toOwnedSlice(alloc);
+    }
+
+    /// Preflight validation of a single policy's control references, feeding the
+    /// same critical/advisory severity model as `config.reviewPolicyFile` (so
+    /// `--strict` aborts on a critical result). Reads and parses `path` itself,
+    /// mirroring `reviewPolicyFile`. Rules (all critical):
+    ///
+    ///   * a malformed or unknown id in `taxonomies.SCF`;
+    ///   * a malformed or unknown id in a `control(...)` shortcode; and
+    ///   * a control-shaped raw `[^ID]` footnote reference in the body (the
+    ///     author must use the `control(id="…")` shortcode so the reference
+    ///     resolves on both the website and the PDF — same web/PDF-divergence
+    ///     rationale as the raw-HTML rule).
+    ///
+    /// Unknown-id checks are skipped when no catalog is loaded (nothing to check
+    /// against). Non-control footnote references are ignored here.
+    pub fn reviewControlRefs(self: *const ControlJoin, io: std.Io, alloc: Allocator, path: []const u8) Config.IssueKind {
+        const content = std.Io.Dir.cwd().readFileAlloc(io, path, alloc, .limited(u.max_policy_bytes)) catch |err| {
+            ctrllog.warn("{s}: cannot read for control validation: {s}", .{ path, @errorName(err) });
+            return .critical;
+        };
+        defer alloc.free(content);
+
+        var worst: Config.IssueKind = .none;
+        worst = maxKind(worst, self.reviewTaxonomy(alloc, path, content));
+        worst = maxKind(worst, self.reviewShortcodes(path, content));
+        worst = maxKind(worst, self.reviewDanglingRefs(alloc, path, content));
+        return worst;
+    }
+
+    /// `taxonomies.SCF` ids: malformed shape or (when a catalog is present)
+    /// unknown id → critical.
+    fn reviewTaxonomy(self: *const ControlJoin, alloc: Allocator, path: []const u8, content: []const u8) Config.IssueKind {
+        var fm = zigmark.Frontmatter.initFromMarkdown(alloc, content) catch |err| {
+            // Front-matter parse failures are reported by config.reviewPolicyFile;
+            // don't double-count them as a control problem here.
+            ctrllog.debug("{s}: front matter unparseable for control validation: {s}", .{ path, @errorName(err) });
+            return .none;
+        };
+        defer fm.deinit();
+
+        const scf = fm.get("taxonomies.SCF") orelse return .none;
+        if (scf != .array) return .none;
+
+        var worst: Config.IssueKind = .none;
+        for (scf.array.items) |item| {
+            if (item != .string) continue;
+            const id = item.string;
+            if (!isControlId(id)) {
+                ctrllog.warn("{s}: malformed SCF control id '{s}' in taxonomies.SCF (expected e.g. IAC-01)", .{ path, id });
+                worst = .critical;
+            } else if (self.catalog) |*cat| {
+                if (!cat.map.contains(id)) {
+                    ctrllog.warn("{s}: unknown SCF control id '{s}' in taxonomies.SCF (not in data/scf.json)", .{ path, id });
+                    worst = .critical;
+                }
+            }
+        }
+        return worst;
+    }
+
+    /// `control(...)` shortcodes in the body: an unknown (but well-formed) id →
+    /// critical; any `control(` opener the strict pattern did not consume is a
+    /// malformed shortcode → critical (mirrors `utils.replace_control_refs`).
+    fn reviewShortcodes(self: *const ControlJoin, path: []const u8, content: []const u8) Config.IssueKind {
+        const opener: mvzr.Regex = mvzr.compile("\\{\\{\\s*control\\(").?;
+        if (!opener.isMatch(content)) return .none;
+        const strict: mvzr.Regex = mvzr.compile("\\{\\{\\s*control\\(id=\"[A-Z]{2,5}-[0-9]{2}(\\.[0-9]+)*\"\\)\\s*\\}\\}").?;
+
+        var worst: Config.IssueKind = .none;
+
+        var strict_count: usize = 0;
+        var it = strict.iterator(content);
+        while (it.next()) |m| {
+            strict_count += 1;
+            const key = "id=\"";
+            const s = std.mem.indexOf(u8, m.slice, key) orelse continue;
+            const id_start = s + key.len;
+            const id_end = std.mem.indexOfScalarPos(u8, m.slice, id_start, '"') orelse continue;
+            const id = m.slice[id_start..id_end];
+            if (self.catalog) |*cat| {
+                if (!cat.map.contains(id)) {
+                    ctrllog.warn("{s}: unknown SCF control id '{s}' in a control() shortcode (not in data/scf.json)", .{ path, id });
+                    worst = .critical;
+                }
+            }
+        }
+
+        var opener_count: usize = 0;
+        var oit = opener.iterator(content);
+        while (oit.next()) |_| opener_count += 1;
+        if (opener_count > strict_count) {
+            ctrllog.warn("{s}: malformed control() shortcode (bad or missing id; use the control(id=\"IAC-01\") form)", .{path});
+            worst = .critical;
+        }
+        return worst;
+    }
+
+    /// Control-shaped raw `[^ID]` footnote references with no definition in the
+    /// body → critical. Parses the raw body (shortcodes are still `{{ … }}`
+    /// text at this stage, so only author-typed `[^…]` refs are found).
+    fn reviewDanglingRefs(_: *const ControlJoin, alloc: Allocator, path: []const u8, content: []const u8) Config.IssueKind {
+        var parser = zigmark.Parser.init();
+        defer parser.deinit(alloc);
+        var doc = parser.parseMarkdown(alloc, content) catch |err| {
+            ctrllog.debug("{s}: body unparseable for footnote validation: {s}", .{ path, @errorName(err) });
+            return .none;
+        };
+        defer doc.deinit(alloc);
+
+        const dangs = zigmark.footnotes.dangling(alloc, &doc) catch return .none;
+        defer {
+            for (dangs) |d| alloc.free(d);
+            alloc.free(dangs);
+        }
+
+        var worst: Config.IssueKind = .none;
+        for (dangs) |label| {
+            if (!isControlId(label)) continue;
+            ctrllog.warn(
+                "{s}: raw footnote reference '[^{s}]' in the body; use the control(id=\"{s}\") shortcode so it resolves on both the website and the PDF",
+                .{ path, label, label },
+            );
+            worst = .critical;
+        }
+        return worst;
+    }
+};
+
+fn lessThanStr(_: void, lhs: []const u8, rhs: []const u8) bool {
+    return std.mem.order(u8, lhs, rhs) == .lt;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test "isControlId: shapes accepted and rejected" {
+    try tst.expect(isControlId("IAC-01"));
+    try tst.expect(isControlId("HRS-05.1"));
+    try tst.expect(isControlId("IAC-21.5"));
+    try tst.expect(isControlId("ABCDE-01")); // 5 letters
+    try tst.expect(isControlId("GOV-01.2.3"));
+    try tst.expect(!isControlId("iac-01")); // lowercase
+    try tst.expect(!isControlId("A-01")); // 1 letter
+    try tst.expect(!isControlId("ABCDEF-01")); // 6 letters
+    try tst.expect(!isControlId("IAC-1")); // 1 digit
+    try tst.expect(!isControlId("IAC01")); // no hyphen
+    try tst.expect(!isControlId("IAC-01.")); // trailing dot
+    try tst.expect(!isControlId("IAC-01.x")); // non-digit sub
+    try tst.expect(!isControlId(""));
+}

--- a/src/golden.zig
+++ b/src/golden.zig
@@ -12,6 +12,7 @@ const std = @import("std");
 const Config = @import("config").Config;
 const typst = @import("typst");
 const reports = @import("reports");
+const controls = @import("controls");
 
 pub const Mode = enum { plain, redact, draft };
 
@@ -41,6 +42,32 @@ pub fn renderFixture(io: std.Io, alloc: std.mem.Allocator, fixture: []const u8, 
     conf.is_draft = (mode == .draft);
 
     var rendered = try typst.render(io, alloc, conf, fixture);
+    defer rendered.deinit(alloc);
+    return alloc.dupe(u8, rendered.source);
+}
+
+/// Render the control-footnote fixture with a fixture-backed `ControlJoin`
+/// context (small committed catalog + join under src/test, and the fixture
+/// itself as the sole library policy). Proves that inline `control(...)`
+/// references become native `#footnote[…]` with the resolved title / spine /
+/// covering-policy text. Fully deterministic. Caller owns the slice.
+pub fn renderControlFixture(io: std.Io, alloc: std.mem.Allocator) ![]u8 {
+    var conf = try Config.load(io, alloc, golden_config);
+    defer conf.deinit(alloc);
+    conf.date = .{ .year = 2026, .month = 1, .day = 1 };
+    conf.current_year = 2026;
+
+    const fixture = "src/test/test_policy_controls.md";
+    var cj = try controls.ControlJoin.init(
+        io,
+        alloc,
+        "src/test/controls_catalog.json",
+        "src/test/controls_join.json",
+        &.{fixture},
+    );
+    defer cj.deinit();
+
+    var rendered = try typst.renderWithControls(io, alloc, conf, fixture, cj.resolver());
     defer rendered.deinit(alloc);
     return alloc.dupe(u8, rendered.source);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -26,6 +26,8 @@ const reports = @import("reports");
 const writeStamp = @import("utils").writeStamp;
 const audit = @import("audit.zig");
 const diagrams = @import("diagrams.zig");
+const controls = @import("controls");
+const zigmark = @import("zigmark");
 
 // ---------------------------------------------------------------------------
 // Logging
@@ -444,6 +446,39 @@ fn runBuild(io: std.Io, env: *EnvMap, alloc: Allocator, args: []const [:0]const 
     // since-deleted policy still leaves its PDF at a guessable URL otherwise.
     try sweepStalePdfs(io, alloc, config, output_path, policies.items);
 
+    // --- Control-ID join ---
+    // One read-only join (SCF catalog + optional praxis join + a library of the
+    // non-draft policies) drives both control-footnote resolution during compile
+    // and the control-reference preflight below. Built once here so it is shared
+    // (by resolver value) across the concurrent compile task group. A missing
+    // catalog degrades gracefully; a configured-but-unloadable praxis join is a
+    // hard error (see ControlJoin.init).
+    const scf_catalog_path = try std.fs.path.join(alloc, &.{ config.root, reports.Kind.scf.catalogFile().? });
+    defer alloc.free(scf_catalog_path);
+    const scf_exists = blk: {
+        std.Io.Dir.cwd().access(io, scf_catalog_path, .{}) catch break :blk false;
+        break :blk true;
+    };
+    const join_path: ?[]const u8 = if (config.praxis_join) |rel|
+        try std.fs.path.join(alloc, &.{ config.root, rel })
+    else
+        null;
+    defer if (join_path) |p| alloc.free(p);
+
+    var policy_paths = try alloc.alloc([]const u8, policies.items.len);
+    defer alloc.free(policy_paths);
+    for (policies.items, 0..) |p, i| policy_paths[i] = p.path;
+
+    var control_join = try controls.ControlJoin.init(
+        io,
+        alloc,
+        if (scf_exists) scf_catalog_path else null,
+        join_path,
+        policy_paths,
+    );
+    defer control_join.deinit();
+    const control_resolver: ?zigmark.footnotes.Resolver = control_join.resolver();
+
     // --- Front-matter validation (pre-flight) ---
     // Warn on incomplete front matter; with --strict, fail on audit-critical
     // gaps. Runs over every current policy (not just the rebuild subset) so a
@@ -453,7 +488,12 @@ fn runBuild(io: std.Io, env: *EnvMap, alloc: Allocator, args: []const [:0]const 
         var critical: usize = 0;
         var advisory: usize = 0;
         for (policies.items) |p| {
-            switch (config.reviewPolicyFile(io, alloc, p.path)) {
+            // The more severe of the front-matter/body review and the
+            // control-reference review, folded into the same counters.
+            const fm_kind = config.reviewPolicyFile(io, alloc, p.path);
+            const ctl_kind = control_join.reviewControlRefs(io, alloc, p.path);
+            const kind = if (@intFromEnum(fm_kind) >= @intFromEnum(ctl_kind)) fm_kind else ctl_kind;
+            switch (kind) {
                 .none => {},
                 .advisory => advisory += 1,
                 .critical => critical += 1,
@@ -566,6 +606,7 @@ fn runBuild(io: std.Io, env: *EnvMap, alloc: Allocator, args: []const [:0]const 
             alloc,
             config,
             p.path,
+            control_resolver,
             stamps_dir_path,
             compile_node,
             &error_mutex,
@@ -887,6 +928,7 @@ fn compileOne(
     alloc: Allocator,
     config: Config,
     input_path: []const u8,
+    resolver: ?zigmark.footnotes.Resolver,
     stamps_dir: []const u8,
     progress_node: std.Progress.Node,
     error_mutex: *std.Io.Mutex,
@@ -895,7 +937,7 @@ fn compileOne(
 ) void {
     defer progress_node.completeOne();
 
-    Typst.compile(io, env, alloc, config, input_path) catch |err| {
+    Typst.compile(io, env, alloc, config, input_path, resolver) catch |err| {
         error_mutex.lockUncancelable(io);
         defer error_mutex.unlock(io);
         error_count.* += 1;

--- a/src/test.zig
+++ b/src/test.zig
@@ -15,6 +15,7 @@ const typst = @import("typst");
 const utils = @import("utils");
 const zigmark = @import("zigmark");
 const praxis_join = @import("praxis_join");
+const controls = @import("controls");
 
 const audit = @import("audit.zig");
 const diagrams = @import("diagrams.zig");
@@ -197,7 +198,7 @@ test "pdf rendering" {
     // test_policy.md contains a mermaid diagram: unlike the pandoc pipeline
     // (which needed Chrome for mermaid-filter), pozeiden renders it in-process
     // so the full pipeline works even inside the Nix sandbox.
-    typst.compile(io, &env, tst.allocator, conf, "src/test/test_policy.md") catch |e| {
+    typst.compile(io, &env, tst.allocator, conf, "src/test/test_policy.md", null) catch |e| {
         std.debug.print("Test Policy Typst Call Failed! \nConfig:{f}\n", .{conf});
         return e;
     };
@@ -966,12 +967,12 @@ test "redact: multiple blocks are all redacted" {
     try tst.expect(std.mem.indexOf(u8, ts.items, "secret") == null);
 }
 
-test "control refs: a valid reference is rewritten to its bare id" {
+test "control refs: a valid reference is rewritten to a footnote reference" {
     var ts = Array(u8).empty;
     defer ts.deinit(tst.allocator);
     try ts.appendSlice(tst.allocator, "Access is least-privilege {{ control(id=\"IAC-01\") }} enforced.");
     try utils.replace_control_refs(tst.allocator, &ts);
-    try tst.expectEqualStrings("Access is least-privilege IAC-01 enforced.", ts.items);
+    try tst.expectEqualStrings("Access is least-privilege [^IAC-01] enforced.", ts.items);
 }
 
 test "control refs: multiple references are all rewritten" {
@@ -980,7 +981,7 @@ test "control refs: multiple references are all rewritten" {
     // Second ref uses the no-whitespace form to exercise \s* on both ends.
     try ts.appendSlice(tst.allocator, "See {{ control(id=\"IAC-01\") }} and {{control(id=\"CRY-01\")}}.");
     try utils.replace_control_refs(tst.allocator, &ts);
-    try tst.expectEqualStrings("See IAC-01 and CRY-01.", ts.items);
+    try tst.expectEqualStrings("See [^IAC-01] and [^CRY-01].", ts.items);
 }
 
 test "control refs: a dotted sub-control id is accepted" {
@@ -988,7 +989,7 @@ test "control refs: a dotted sub-control id is accepted" {
     defer ts.deinit(tst.allocator);
     try ts.appendSlice(tst.allocator, "Ref {{ control(id=\"IAC-21.5\") }} here.");
     try utils.replace_control_refs(tst.allocator, &ts);
-    try tst.expectEqualStrings("Ref IAC-21.5 here.", ts.items);
+    try tst.expectEqualStrings("Ref [^IAC-21.5] here.", ts.items);
 }
 
 test "control refs: a malformed id is a hard error" {
@@ -1441,4 +1442,185 @@ test "praxis join: missing schema field is a hard, distinct error" {
     defer alloc.free(p);
 
     try tst.expectError(error.MissingSchema, praxis_join.PraxisJoin.load(io, alloc, p));
+}
+
+// ── Control-ID join (src/controls.zig) ────────────────────────────────────────
+
+/// A ControlJoin over the committed fixtures: catalog IAC-01/DCH-01/NET-02,
+/// spine {IAC-01, NET-02}, library = the single control fixture policy (tags
+/// IAC-01 + DCH-01, titled "Access Control Test Policy").
+fn fixtureControlJoin(alloc: Allocator) !controls.ControlJoin {
+    return controls.ControlJoin.init(
+        io,
+        alloc,
+        "src/test/controls_catalog.json",
+        "src/test/controls_join.json",
+        &.{"src/test/test_policy_controls.md"},
+    );
+}
+
+test "controls: resolveFootnote — covered + in spine" {
+    const alloc = tst.allocator;
+    var cj = try fixtureControlJoin(alloc);
+    defer cj.deinit();
+
+    const md = (try cj.resolveFootnote(alloc, "IAC-01")).?;
+    defer alloc.free(md);
+    try tst.expect(std.mem.startsWith(u8, md, "IAC-01 \u{2014} Identity & Access Management."));
+    try tst.expect(std.mem.indexOf(u8, md, "praxis: in control spine.") != null);
+    try tst.expect(std.mem.indexOf(u8, md, "Covered by: Access Control Test Policy.") != null);
+}
+
+test "controls: resolveFootnote — covered but not in spine" {
+    const alloc = tst.allocator;
+    var cj = try fixtureControlJoin(alloc);
+    defer cj.deinit();
+
+    const md = (try cj.resolveFootnote(alloc, "DCH-01")).?;
+    defer alloc.free(md);
+    try tst.expect(std.mem.indexOf(u8, md, "DCH-01 \u{2014} Data Protection.") != null);
+    try tst.expect(std.mem.indexOf(u8, md, "praxis: not in control spine.") != null);
+    try tst.expect(std.mem.indexOf(u8, md, "Covered by: Access Control Test Policy.") != null);
+}
+
+test "controls: resolveFootnote — in spine but uncovered omits the Covered-by clause" {
+    const alloc = tst.allocator;
+    var cj = try fixtureControlJoin(alloc);
+    defer cj.deinit();
+
+    const md = (try cj.resolveFootnote(alloc, "NET-02")).?;
+    defer alloc.free(md);
+    try tst.expect(std.mem.indexOf(u8, md, "NET-02 \u{2014} Layered Network Defenses.") != null);
+    try tst.expect(std.mem.indexOf(u8, md, "praxis: in control spine.") != null);
+    // No policy tags NET-02, so there is no covering clause.
+    try tst.expect(std.mem.indexOf(u8, md, "Covered by:") == null);
+}
+
+test "controls: resolveFootnote — a non-control label returns null" {
+    const alloc = tst.allocator;
+    var cj = try fixtureControlJoin(alloc);
+    defer cj.deinit();
+
+    try tst.expect((try cj.resolveFootnote(alloc, "not-a-control")) == null);
+    try tst.expect((try cj.resolveFootnote(alloc, "1")) == null);
+}
+
+test "controls: resolveFootnote — no praxis join omits the spine clause" {
+    const alloc = tst.allocator;
+    var cj = try controls.ControlJoin.init(
+        io,
+        alloc,
+        "src/test/controls_catalog.json",
+        null, // no join configured
+        &.{"src/test/test_policy_controls.md"},
+    );
+    defer cj.deinit();
+
+    const md = (try cj.resolveFootnote(alloc, "IAC-01")).?;
+    defer alloc.free(md);
+    try tst.expect(std.mem.indexOf(u8, md, "Identity & Access Management") != null);
+    try tst.expect(std.mem.indexOf(u8, md, "praxis:") == null);
+    try tst.expect(std.mem.indexOf(u8, md, "Covered by: Access Control Test Policy.") != null);
+}
+
+test "controls: resolveFootnote — no catalog omits the title clause" {
+    const alloc = tst.allocator;
+    var cj = try controls.ControlJoin.init(
+        io,
+        alloc,
+        null, // no catalog
+        "src/test/controls_join.json",
+        &.{"src/test/test_policy_controls.md"},
+    );
+    defer cj.deinit();
+
+    const md = (try cj.resolveFootnote(alloc, "IAC-01")).?;
+    defer alloc.free(md);
+    // Just the id (no "— title"), then the spine + covering clauses.
+    try tst.expect(std.mem.startsWith(u8, md, "IAC-01."));
+    try tst.expect(std.mem.indexOf(u8, md, "\u{2014}") == null);
+    try tst.expect(std.mem.indexOf(u8, md, "praxis: in control spine.") != null);
+}
+
+test "controls: reviewControlRefs — clean fixture is none" {
+    const alloc = tst.allocator;
+    var cj = try fixtureControlJoin(alloc);
+    defer cj.deinit();
+    try tst.expectEqual(config.IssueKind.none, cj.reviewControlRefs(io, alloc, "src/test/test_policy_controls.md"));
+}
+
+test "controls: reviewControlRefs — unknown id in taxonomies.SCF is critical" {
+    const alloc = tst.allocator;
+    var cj = try fixtureControlJoin(alloc);
+    defer cj.deinit();
+
+    var tmp = tst.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmpAbsPath(alloc, &tmp);
+    defer alloc.free(tmp_path);
+
+    // GOV-99 is well-formed but not in the fixture catalog.
+    const md =
+        \\---
+        \\title: "Bad Taxonomy"
+        \\taxonomies:
+        \\  SCF:
+        \\    - GOV-99
+        \\---
+        \\Body.
+    ;
+    try tmp.dir.writeFile(io, .{ .sub_path = "bad_tax.md", .data = md });
+    const p = try std.fs.path.join(alloc, &.{ tmp_path, "bad_tax.md" });
+    defer alloc.free(p);
+
+    try tst.expectEqual(config.IssueKind.critical, cj.reviewControlRefs(io, alloc, p));
+}
+
+test "controls: reviewControlRefs — malformed shortcode is critical" {
+    const alloc = tst.allocator;
+    var cj = try fixtureControlJoin(alloc);
+    defer cj.deinit();
+
+    var tmp = tst.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmpAbsPath(alloc, &tmp);
+    defer alloc.free(tmp_path);
+
+    // Lowercase, single-digit id: the strict pattern rejects it, leaving a
+    // control( opener the reviewer flags.
+    const md =
+        \\---
+        \\title: "Bad Shortcode"
+        \\---
+        \\Access {{ control(id="iac-1") }} enforced.
+    ;
+    try tmp.dir.writeFile(io, .{ .sub_path = "bad_sc.md", .data = md });
+    const p = try std.fs.path.join(alloc, &.{ tmp_path, "bad_sc.md" });
+    defer alloc.free(p);
+
+    try tst.expectEqual(config.IssueKind.critical, cj.reviewControlRefs(io, alloc, p));
+}
+
+test "controls: reviewControlRefs — a control-shaped dangling raw ref is critical" {
+    const alloc = tst.allocator;
+    var cj = try fixtureControlJoin(alloc);
+    defer cj.deinit();
+
+    var tmp = tst.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmpAbsPath(alloc, &tmp);
+    defer alloc.free(tmp_path);
+
+    // Author typed a raw footnote reference instead of the shortcode.
+    const md =
+        \\---
+        \\title: "Raw Footnote"
+        \\---
+        \\Access is least-privilege [^IAC-01] enforced.
+    ;
+    try tmp.dir.writeFile(io, .{ .sub_path = "raw_fn.md", .data = md });
+    const p = try std.fs.path.join(alloc, &.{ tmp_path, "raw_fn.md" });
+    defer alloc.free(p);
+
+    try tst.expectEqual(config.IssueKind.critical, cj.reviewControlRefs(io, alloc, p));
 }

--- a/src/test/controls_catalog.json
+++ b/src/test/controls_catalog.json
@@ -1,0 +1,17 @@
+[
+  {
+    "domain": "Identity & Access Management",
+    "control_id": "IAC-01",
+    "control": "Identity & Access Management"
+  },
+  {
+    "domain": "Data Classification & Handling",
+    "control_id": "DCH-01",
+    "control": "Data Protection"
+  },
+  {
+    "domain": "Network Security",
+    "control_id": "NET-02",
+    "control": "Layered Network Defenses"
+  }
+]

--- a/src/test/controls_join.json
+++ b/src/test/controls_join.json
@@ -1,0 +1,10 @@
+{
+  "schema": "policypress/praxis-join/v1",
+  "generated_at": "2026-01-01",
+  "source": {
+    "rev": "test-fixture",
+    "scf_version": "2026.1.1"
+  },
+  "organizational_families": ["IAC"],
+  "ids": ["IAC-01", "NET-02"]
+}

--- a/src/test/test_policy_controls.md
+++ b/src/test/test_policy_controls.md
@@ -1,0 +1,27 @@
+---
+title: "Access Control Test Policy"
+description: "Fixture exercising inline control-ID footnotes (SCF + praxis join)"
+date: 2024-11-13
+weight: 10
+taxonomies:
+  SCF:
+    - IAC-01
+    - DCH-01
+extra:
+  owner: SC2
+  last_reviewed: 2025-02-24
+  major_revisions:
+    - date: 2025-06-24
+      description: Initial version.
+      revised_by: Ada Byrne
+      approved_by: Ada Byrne
+      version: "1.0"
+---
+
+## Purpose
+
+Access is least-privilege {{ control(id="IAC-01") }} enforced across all systems.
+
+## Data protection
+
+All data is classified and protected {{ control(id="DCH-01") }} according to its sensitivity.

--- a/src/typst.zig
+++ b/src/typst.zig
@@ -129,8 +129,12 @@ pub fn compile(
     alloc: Allocator,
     config: Config,
     input_file: []const u8,
+    /// Control-footnote resolver (from `controls.ControlJoin`), or null to leave
+    /// footnote references undefined. Read-only, so it is safe to copy into each
+    /// concurrent compile task.
+    resolver: ?zigmark.footnotes.Resolver,
 ) !void {
-    var rendered = try render(io, alloc, config, input_file);
+    var rendered = try renderWithControls(io, alloc, config, input_file, resolver);
     defer rendered.deinit(alloc);
 
     try compileSource(io, env, alloc, config, rendered.source, std.fs.path.basename(input_file), rendered.pdf_name);
@@ -214,11 +218,32 @@ pub fn outputName(io: std.Io, alloc: Allocator, config: Config, input_file: []co
 /// Render a Markdown policy file to a complete Typst source. Split out from
 /// `compile` so tests can assert on the generated markup without a typst
 /// binary. Caller owns the result (free via `Rendered.deinit`).
+///
+/// This is the control-free path: footnote references are left unresolved, so
+/// output is byte-identical to the pre-#164 renderer (the golden baselines
+/// depend on this). Pass a resolver via `renderWithControls` to synthesise
+/// control footnotes.
 pub fn render(
     io: std.Io,
     alloc: Allocator,
     config: Config,
     input_file: []const u8,
+) !Rendered {
+    return renderWithControls(io, alloc, config, input_file, null);
+}
+
+/// As `render`, but when `resolver` is non-null every undefined footnote
+/// reference is offered to it (`zigmark.footnotes.resolve`) between parsing and
+/// rendering, so inline control references (`[^IAC-01]`, produced from the
+/// `control(...)` shortcode by `replace_control_refs`) become native
+/// `#footnote[…]`. A null resolver leaves the AST untouched — byte-identical to
+/// the pre-#164 output.
+pub fn renderWithControls(
+    io: std.Io,
+    alloc: Allocator,
+    config: Config,
+    input_file: []const u8,
+    resolver: ?zigmark.footnotes.Resolver,
 ) !Rendered {
     log.debug("Processing markdown file: {s}\n", .{input_file});
 
@@ -284,6 +309,15 @@ pub fn render(
     defer parser.deinit(alloc);
     var doc = try parser.parseMarkdown(alloc, contents.items);
     defer doc.deinit(alloc);
+
+    // Synthesise control-footnote definitions for the `[^ID]` references that
+    // `replace_control_refs` produced from `control(...)` shortcodes. Only when a
+    // resolver is supplied — a null resolver leaves the AST (and every existing
+    // golden) byte-identical. Uses the same parser flags so a synthesised body
+    // parses like the host document.
+    if (resolver) |r| {
+        _ = try zigmark.footnotes.resolve(alloc, &doc, r, .{ .parser = parser });
+    }
 
     // Only pull in mitex when math is both enabled and actually present, so a
     // policy that opts in but writes no `$…$` still produces a mitex-free PDF.

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -265,13 +265,14 @@ pub fn replace_org(alloc: Allocator, txt: *Array(u8), with: []const u8) !void {
     txt.* = new;
 }
 
-/// PDF pre-pass stopgap for inline control references.
+/// PDF pre-pass for inline control references.
 ///
-/// Rewrites every `{{ control(id="IAC-01") }}` shortcode to the bare control id
-/// text (`IAC-01`) so demo PDFs never show literal shortcode syntax. This is a
-/// placeholder: a later subissue (#164) upgrades the rewrite to a `[^IAC-01]`
-/// footnote reference resolved against the SCF catalog + praxis join. The website
-/// renders the same shortcode as a link via templates/shortcodes/control.html.
+/// Rewrites every `{{ control(id="IAC-01") }}` shortcode to a Markdown footnote
+/// reference (`[^IAC-01]`). The control-ID join (`src/controls.zig`) then
+/// synthesises the matching footnote definition — control title + praxis spine
+/// status + covering policies — which zigmark's Typst renderer expands into a
+/// native `#footnote[…]`. The website renders the same shortcode as a link via
+/// templates/shortcodes/control.html.
 ///
 /// Strictness mirrors `redact`'s orphan-tag handling: the id must match
 /// `[A-Z]{2,5}-[0-9]{2}(\.[0-9]+)*` exactly. Any `control(` construct that does
@@ -300,7 +301,12 @@ pub fn replace_control_refs(alloc: Allocator, txt: *Array(u8)) !void {
         const id_end = std.mem.indexOfScalarPos(u8, m.slice, id_start, '"') orelse return error.InvalidShortCode;
         const id = m.slice[id_start..id_end];
 
-        try new.replaceRange(alloc, m.start, m.slice.len, id);
+        // Emit a footnote reference `[^<id>]`; controls.zig synthesises the
+        // definition so the Typst renderer produces a native `#footnote[…]`.
+        const fnref = try std.fmt.allocPrint(alloc, "[^{s}]", .{id});
+        defer alloc.free(fnref);
+
+        try new.replaceRange(alloc, m.start, m.slice.len, fnref);
         iter = ref.iterator(new.items);
     }
     txt.deinit(alloc);

--- a/tests/golden/test_policy_controls.typ
+++ b/tests/golden/test_policy_controls.typ
@@ -1,0 +1,118 @@
+#set document(
+  title: "Access Control Test Policy",
+  author: "Star City Security Consulting",
+)
+
+#set image(alt: "Diagram")
+
+#set page(
+  paper: "us-letter",
+  margin: (x: 2.5cm, y: 2.5cm),
+  header: [
+    #set text(size: 9pt, fill: rgb("#777777"))
+    #grid(
+      columns: (1fr, 1fr, 1fr),
+      align: (left, center, right),
+      [Access Control Test Policy v1.0],
+      [],
+      [#image("/static/logo.png", height: 20pt)],
+    )
+  ],
+  footer: [
+    #set text(size: 9pt, fill: rgb("#777777"))
+    #grid(
+      columns: (1fr, 1fr, 1fr),
+      align: (left, center, right),
+      [Star City Security Consulting © 2026],
+      [Confidential],
+      [#context counter(page).display("1")],
+    )
+  ],
+)
+
+#set text(
+  font: "Source Sans 3",
+  size: 11pt,
+  lang: "en",
+)
+
+#show raw: set text(font: ("Source Code Pro", "DejaVu Sans Mono"))
+
+#show raw.where(block: true): it => block(
+  fill: rgb("#F7F7F7"),
+  inset: 10pt,
+  radius: 4pt,
+  width: 100%,
+  stroke: 0.5pt + rgb("#DDDDDD"),
+  it,
+)
+
+#show heading: it => {
+  set text(fill: rgb("#282828"))
+  it
+}
+
+#show link: set text(fill: rgb("#A50000"))
+
+#show figure.caption: it => {
+  set text(fill: rgb("#777777"), size: 9pt)
+  it
+}
+
+#set table(
+  fill: (_, row) => if row == 0 { rgb("#EEEEEE") } else if calc.odd(row) { white } else { rgb("#F7F7F7") },
+  stroke: rgb("#999999"),
+)
+
+// ── Title page ─────────────────────────────────────────────────────────
+#page(
+  margin: (x: 2.5cm, y: 2.5cm),
+  header: none,
+  footer: none,
+)[
+  #v(3cm)
+
+  #heading(level: 1, outlined: false)[#text(size: 36pt, weight: "bold")[Access Control Test Policy]]
+
+  #v(0.5cm)
+  #text(size: 18pt)[Version v1.0]
+
+  #v(1.5cm)
+  #line(length: 100%, stroke: 4pt + rgb("#0e90f3"))
+
+  #text(size: 18pt)[Star City Security Consulting]
+
+  #v(1fr)
+
+  #image("/static/logo.png", width: 6cm)
+
+  #text(size: 11pt)[Last Reviewed: 2025-02-24]
+]
+
+#outline(
+  title: "Contents",
+  depth: 3,
+)
+
+== Purpose
+Access is least-privilege #footnote[IAC-01 — Identity & Access Management. praxis: in control spine. Covered by: Access Control Test Policy.] enforced across all systems.
+
+== Data protection
+All data is classified and protected #footnote[DCH-01 — Data Protection. praxis: not in control spine. Covered by: Access Control Test Policy.] according to its sensitivity.
+
+
+#pagebreak()
+= Version History
+
+#table(
+  columns: (auto, auto, 1fr, auto, auto),
+  align: (center, center, left, center, center),
+  table.header(
+    [*Version*], [*Date*], [*Description*], [*Revised By*], [*Approved By*],
+  ),
+  [1.0],
+  [2025-06-24],
+  [Initial version.],
+  [Ada Byrne],
+  [Ada Byrne],
+)

--- a/tools/golden_gen.zig
+++ b/tools/golden_gen.zig
@@ -21,6 +21,16 @@ pub fn main(init: std.process.Init) !void {
     }
     const fixture = argv[1];
 
+    if (std.mem.eql(u8, fixture, "--controls")) {
+        const src = try golden.renderControlFixture(io, alloc);
+        defer alloc.free(src);
+        var buf: [4096]u8 = undefined;
+        var out = std.Io.File.stdout().writer(io, &buf);
+        try out.interface.writeAll(src);
+        try out.interface.flush();
+        return;
+    }
+
     if (std.mem.eql(u8, fixture, "--report")) {
         if (argv.len < 3) {
             std.debug.print("usage: golden_gen --report <scf|soc2|review>\n", .{});


### PR DESCRIPTION
Closes #164. Part of #127.

**Stacked on #168** (B2, `feat/control-shortcode-web`) which is itself stacked on #167 (B1). This PR's base will retarget to `main` once #168 merges. Review/merge after the parents.

## What this does

Inline control references authored as `{{ control(id="IAC-01") }}` (which B2's `replace_control_refs` rewrites to a `[^IAC-01]` footnote reference) become **native Typst footnotes** in policy PDFs, carrying:

`IAC-01 — <SCF title>. praxis: in control spine|not in control spine. Covered by: <policy titles>.`

Every clause degrades independently: no catalog → just the id; no praxis join → no spine clause; no covering policy → no "Covered by" clause. The footnote is always valid.

## Changes

- **zigmark pin → v0.11.0** (`build.zig.zon` + regenerated `build.zig.zon2json-lock`): `footnotes.resolve`/`dangling`, relaxed footnote-definition label charset, `Library.footnoteResolver`. Pin sha `63f68d4dd759836e35900b75a140a35ed7ab2223`.
- **`replace_control_refs`** now emits `[^IAC-01]` instead of the bare-id stopgap; strict malformed-id hard error retained.
- **New `src/controls.zig` `ControlJoin`**: binds the SCF catalog (`control_report.zig`), the optional praxis join, and a `zigmark.Library` of the non-draft policies (fed per-file, never `addFromDir`). Produces the `zigmark.footnotes.Resolver`. `control_report.zig coverage()` is untouched — this is purely additive.
- **`typst.zig`**: `render` becomes a control-free wrapper (`resolver = null` → byte-identical to today); `renderWithControls` runs `footnotes.resolve` between parse and render.
- **`main.zig`**: builds one read-only `ControlJoin` after the policy walk and threads its resolver through the concurrent compile task group. `reviewControlRefs` joins the `--strict` preflight: malformed/unknown ids in `taxonomies.SCF` or `control(...)` shortcodes → critical; control-shaped dangling raw `[^ID]` refs → critical (pointing at the shortcode); unloadable praxis join → hard error; spine ids missing from the local catalog → warning.
- **Goldens/tests**: new `test_policy_controls.typ` baseline rendered with a fixture-backed context; unit tests for resolver variants (covered / uncovered / in-spine / not-in-spine / no-join / no-catalog / non-control-label), the validation rules, and the `[^id]` rewrite.

Scope-exclusions, `coverage.json` changes, and the audit `join.json` facet are **out of scope** (#165/#166).

## Verification

- `zig build test` — green; existing goldens byte-identical (`update-golden` added only the new baseline).
- `zig build e2e` — starter (no scf.json / no join) builds; its inline ref renders a valid degraded footnote (`#footnote[IAC-01. Covered by: Access Control Policy.]`).
- Full demo build — Example Security Policy PDF compiles; the three inline refs render as e.g. `#footnote[IAC-01 — Identity & Access Management (IAM). praxis: in control spine. Covered by: Example Security Policy.]`.