### PR TITLE
feat: scope-exclusion policies + control-coverage annex

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -108,6 +108,16 @@ pub fn build(b: *std.Build) !void {
         _ = b.step("preview", "Serve the zola output (Not available on Windows. run `zola preview` instead.)");
     }
 
+    // Plain data contract for the PDF control-coverage annex (#165). A leaf
+    // module (std only) so both typst (consumer) and controls (producer) can
+    // import it without a cycle — the same trick B3 used for the footnote
+    // resolver value.
+    const control_annex_mod = b.addModule("control_annex", .{
+        .root_source_file = b.path("src/control_annex.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
     // Typst PDF engine: markdown → zigmark → Typst markup (mermaid via
     // pozeiden) → `typst compile`.
     const typst_mod = b.addModule("typst_engine", .{
@@ -121,6 +131,7 @@ pub fn build(b: *std.Build) !void {
     typst_mod.addImport("zigmark", zigmark_mod);
     typst_mod.addImport("pozeiden", pozeiden_mod);
     typst_mod.addImport("praxis_join", praxis_join_mod);
+    typst_mod.addImport("control_annex", control_annex_mod);
     const typst_exe = b.addExecutable(.{
         .root_module = typst_mod,
         .name = "pdf_engine",
@@ -163,6 +174,7 @@ pub fn build(b: *std.Build) !void {
     controls_mod.addImport("config", config_mod);
     controls_mod.addImport("utils", utils_mod);
     controls_mod.addImport("mvzr", mvzr.module("mvzr"));
+    controls_mod.addImport("control_annex", control_annex_mod);
 
     // Shared render helper for the golden Typst-markup snapshots (used by both
     // golden_test.zig and tools/golden_gen.zig).
@@ -195,6 +207,7 @@ pub fn build(b: *std.Build) !void {
     policypress_mod.addImport("utils", utils_mod);
     policypress_mod.addImport("praxis_join", praxis_join_mod);
     policypress_mod.addImport("controls", controls_mod);
+    policypress_mod.addImport("control_annex", control_annex_mod);
     // Build-time mermaid rendering for the site (src/diagrams.zig, `render-diagrams`).
     policypress_mod.addImport("pozeiden", pozeiden_mod);
     const policypress_exe = b.addExecutable(.{

--- a/content/guides/adding-a-policy.md
+++ b/content/guides/adding-a-policy.md
@@ -68,6 +68,7 @@ extra:
 | `extra.owner` | no | The individual responsible for the policy. Shown in the revision table |
 | `extra.last_reviewed` | yes | ISO date (`YYYY-MM-DD`) of the last formal review. A warning shows if this is more than a year ago |
 | `extra.major_revisions` | yes | At least one entry is required. See below |
+| `extra.scope_exclusions` | no | Controls this policy formally declares out of scope. A list of `{ id, reason }` entries. See "Declaring controls out of scope" below |
 
 ### Revision entries
 
@@ -90,6 +91,39 @@ Tagging controls links this policy to the SCF and SOC 2 coverage reports. Values
 **TSC2017** uses SOC 2 Trust Services Criteria identifiers (e.g. `CC6.1`, `A1.2`). See the SOC 2 report page.
 
 Any taxonomy declared in `config.toml` will show up in the Framework Coverage section on the policy page, even without a dedicated report.
+
+> **Unknown or malformed control IDs now fail `--strict` builds.** A control tagged in `taxonomies.SCF` (or referenced inline, or excluded — see below) that is not in the SCF catalog, or that does not match the `AA-00` / `AA-00.0` shape, is an audit-critical error. Regular builds log a warning; `policypress build --strict` (used in CI) aborts.
+
+## Declaring controls out of scope
+
+Sometimes the right answer for a control is "we deliberately do not do this". Use `extra.scope_exclusions` to record that decision so it is auditable rather than looking like an oversight:
+
+```yaml
+extra:
+  scope_exclusions:
+    - id: PES-01
+      reason: "We operate no physical facilities; all infrastructure is colocated with certified providers."
+    - id: PES-04
+      reason: "No offices or server rooms require physical access control; staff work remotely."
+```
+
+Each entry needs an `id` (a valid SCF control ID) and a non-empty `reason`.
+
+An exclusion is **not** coverage — it is a distinct third state:
+
+- The policy page shows a **Declared Out of Scope** card listing each excluded control and its reason.
+- The SCF coverage report shows the control as *"Declared out of scope by \<policy\>"* instead of *"No policies mapped"* — but the exclusion never counts toward the coverage percentage.
+- The policy PDF gains a **Control Coverage** annex with a *Declared out of scope* subsection.
+- The audit bundle's `coverage.json` records the excluding policy titles under `excluded_by`.
+
+Validation (audit-critical, so it fails `--strict`):
+
+| Rule | Severity |
+|---|---|
+| `id` malformed or not in the SCF catalog | critical |
+| Missing or empty `reason` | critical |
+| The same policy lists an ID in both `taxonomies.SCF` and `scope_exclusions` | critical |
+| A control excluded here is covered by *another* published policy | advisory (a governance tension to reconcile, not a build failure) |
 
 ## Writing the policy content
 

--- a/content/policies/physical-security-exclusion.md
+++ b/content/policies/physical-security-exclusion.md
@@ -1,0 +1,43 @@
+---
+title: "Physical Security Policy"
+description: "Physical and environmental security posture for a fully-colocated organization, including the controls formally out of scope."
+summary: "This policy documents the organization's physical security posture. Because all infrastructure is colocated with certified providers, several physical controls are formally declared out of scope."
+date: 2026-02-01
+weight: 20
+taxonomies:
+  SCF:
+    - AST-01
+    - AST-02
+  TSC2017:
+    - CC6.4
+extra:
+  owner: Ada Byrne
+  last_reviewed: 2026-02-01
+  scope_exclusions:
+    - id: PES-01
+      reason: "We operate no physical facilities of our own; all production infrastructure is colocated with SOC 2-certified providers whose physical and environmental protections are inherited under a shared-responsibility model."
+    - id: PES-04
+      reason: "The organization maintains no offices, server rooms, or facilities requiring physical access control; staff work remotely and all systems are provider-hosted."
+  major_revisions:
+    - date: 2026-02-01
+      description: Initial physical security policy establishing the colocation posture and formally scoping out on-premises physical controls.
+      revised_by: Chidi Diallo
+      approved_by: Ada Byrne
+      version: "1.0"
+---
+
+## Purpose and Scope
+
+{{ org() }} does not own or operate any physical data-center or office facilities. All production systems are hosted by colocation and cloud providers that maintain their own certified physical and environmental protections. This policy documents the physical security responsibilities that remain with {{ org() }} and formally records the physical controls that are out of scope as a result.
+
+## Asset Governance
+
+{{ org() }} maintains an authoritative inventory of all information assets {{ control(id="AST-01") }}, including provider-hosted systems, endpoints, and the personnel accountable for each. Asset inventories {{ control(id="AST-02") }} are reviewed quarterly and reconciled against provider billing and access records.
+
+## Provider Responsibility
+
+Physical access to the systems that process {{ org() }} data is governed entirely by our providers' controls, which are evidenced through their SOC 2 Type II reports and reviewed annually as part of vendor due diligence.
+
+## Out-of-Scope Controls
+
+The controls listed in the "Declared Out of Scope" section of this policy do not apply to {{ org() }} because the organization operates no physical premises. Each exclusion is inherited from a certified provider under a shared-responsibility model and is auditable against that provider's attestations.

--- a/sass/components/_reports.scss
+++ b/sass/components/_reports.scss
@@ -163,6 +163,29 @@
             border-radius: 4px;
             text-align: center;
           }
+
+          // Third state (#165): an uncovered control that a policy deliberately
+          // declares out of scope. Distinct from .no-policies (a silent gap) —
+          // a warning-toned left rule and the explicit "Declared out of scope"
+          // text carry the distinction without relying on colour alone.
+          .declared-out-of-scope {
+            color: var(--bs-body-color);
+            padding: 1rem;
+            background: var(--pp-section-title-bg);
+            border: 1px solid var(--bs-border-color);
+            border-left: 3px solid var(--bs-warning);
+            border-radius: 4px;
+
+            a {
+              color: var(--bs-link-color);
+              text-decoration: none;
+
+              &:hover {
+                color: var(--bs-link-hover-color);
+                text-decoration: underline;
+              }
+            }
+          }
         }
       }
     }

--- a/sass/components/_satisfies.scss
+++ b/sass/components/_satisfies.scss
@@ -162,3 +162,74 @@ a.control-ref {
 .control-item[id] {
   scroll-margin-top: 1rem;
 }
+
+// "Declared Out of Scope" card on a policy page. Sits just after Framework
+// Coverage but is deliberately styled apart — an exclusion is a documented "we
+// do not do this", never coverage. A warning-toned left rule (not colour
+// alone: the "Declared Out of Scope" label carries the meaning) keeps the two
+// sections from reading as one.
+.scope-exclusions {
+  margin-top: 1.5rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--bs-border-color);
+  border-left: 3px solid var(--bs-warning);
+  border-radius: var(--bs-border-radius);
+  background: var(--bs-tertiary-bg);
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.scope-exclusions-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--bs-secondary-color);
+}
+
+.scope-exclusions-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.scope-exclusion {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.scope-exclusion-id {
+  flex: 0 0 auto;
+  padding: 0.15rem 0.5rem;
+  border-radius: 0.2rem;
+  background: var(--bs-secondary-bg);
+  color: var(--bs-body-color);
+  text-decoration: none;
+  font-family: $font-family-monospace;
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+a.scope-exclusion-id {
+  color: var(--bs-link-color);
+  transition: var(--pp-transition);
+
+  &:hover,
+  &:focus {
+    background: var(--bs-primary-bg-subtle);
+    color: var(--bs-link-hover-color);
+    text-decoration: none;
+  }
+}
+
+.scope-exclusion-reason {
+  flex: 1 1 12rem;
+  color: var(--bs-body-color);
+  font-size: 0.9rem;
+}

--- a/src/audit.zig
+++ b/src/audit.zig
@@ -184,7 +184,7 @@ pub fn writeBundle(
     {
         var frameworks = std.json.Array.init(a);
         var csv: std.Io.Writer.Allocating = .init(a);
-        try csv.writer.writeAll("framework,control_id,domain,control,covered,policies\n");
+        try csv.writer.writeAll("framework,control_id,domain,control,covered,policies,excluded_by\n");
 
         inline for (.{ reports.Kind.scf, reports.Kind.soc2 }) |kind| {
             const framework_id = switch (kind) {
@@ -216,9 +216,15 @@ pub fn writeBundle(
                     var pols = std.json.Array.init(a);
                     for (c.policies) |p| try pols.append(.{ .string = p });
                     try obj.put(a, "policies", .{ .array = pols });
+                    // Additive per-control field (#165). The schema string is
+                    // unchanged (praxis exact-matches …/v1 and ignores unknown
+                    // keys); an exclusion is neither coverage nor a silent gap.
+                    var excl = std.json.Array.init(a);
+                    for (c.excluded_by) |p| try excl.append(.{ .string = p });
+                    try obj.put(a, "excluded_by", .{ .array = excl });
                     try controls.append(.{ .object = obj });
 
-                    // CSV row (policies ;-joined).
+                    // CSV row (policies and exclusions each ;-joined).
                     try writeCsvField(&csv.writer, framework_id);
                     try csv.writer.writeByte(',');
                     try writeCsvField(&csv.writer, c.control_id);
@@ -229,6 +235,9 @@ pub fn writeBundle(
                     try csv.writer.writeAll(if (c.policies.len > 0) ",true," else ",false,");
                     const joined = try std.mem.join(a, "; ", c.policies);
                     try writeCsvField(&csv.writer, joined);
+                    try csv.writer.writeByte(',');
+                    const excl_joined = try std.mem.join(a, "; ", c.excluded_by);
+                    try writeCsvField(&csv.writer, excl_joined);
                     try csv.writer.writeByte('\n');
                 }
 

--- a/src/control_annex.zig
+++ b/src/control_annex.zig
@@ -1,0 +1,50 @@
+//! Copyright © 2025 [Star City Security Consulting, LLC (SC2)](https://sc2.in)
+//! SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+//!
+//! Plain data contract for the PDF "Control Coverage" annex (#127 / #165).
+//!
+//! Frontmatter control/criterion tags (`taxonomies.SCF`, `taxonomies.TSC2017`)
+//! and scope exclusions (`extra.scope_exclusions`) have no in-text anchor, so —
+//! unlike inline `control(...)` references, which become footnotes — they are
+//! rendered as an annex table at the end of a policy PDF.
+//!
+//! `typst.zig` reads the per-policy tags straight from the frontmatter it
+//! already parses, and asks a `Provider` only the one *global* question that
+//! needs the framework catalog: a control's title. The provider's `ctx` is an
+//! opaque pointer to the `controls.ControlJoin` (populated by
+//! `ControlJoin.annexProvider`), so `typst.zig` never imports `controls` — the
+//! same module-cycle discipline B3 used for the footnote resolver. Read-only
+//! after construction, so one provider value is shared across the concurrent
+//! per-policy compile tasks.
+//!
+//! The annex is deliberately praxis-agnostic: praxis-spine membership is an
+//! optional overlay surfaced via the web badges and `audit/join.json`, never
+//! baked into this core table (#127 follow-up).
+//!
+//! This module has no dependencies beyond `std`, so both `typst.zig` (the
+//! consumer) and `controls.zig` (the producer) can import it without a cycle.
+
+const std = @import("std");
+
+/// The two report-backed frameworks a policy can tag. Kept minimal on purpose:
+/// only these two get a coverage annex table (ID | Control/Criterion).
+pub const Framework = enum { scf, tsc2017 };
+
+/// Global display info for one control/criterion id, resolved from the catalog.
+pub const Info = struct {
+    /// Human title from the framework catalog, or null when no catalog is loaded
+    /// or the id is unknown (the annex then shows the id alone). Borrows from the
+    /// catalog's arena, which outlives every render.
+    title: ?[]const u8 = null,
+};
+
+/// A resolver for the annex's title lookup, bound to a `controls.ControlJoin`.
+/// Passed by value into the typst render path alongside the footnote resolver.
+pub const Provider = struct {
+    ctx: ?*anyopaque = null,
+    lookupFn: *const fn (ctx: ?*anyopaque, framework: Framework, id: []const u8) Info,
+
+    pub fn lookup(self: Provider, framework: Framework, id: []const u8) Info {
+        return self.lookupFn(self.ctx, framework, id);
+    }
+};

--- a/src/control_report.zig
+++ b/src/control_report.zig
@@ -219,6 +219,11 @@ pub const ControlCoverage = struct {
     /// Titles of policies whose taxonomy lists this control, sorted. Empty
     /// when the control is uncovered.
     policies: []const []const u8,
+    /// Titles of policies that declare this control out of scope
+    /// (`extra.scope_exclusions`), sorted. Empty when nothing excludes it.
+    /// An exclusion is a *third* state: it is neither coverage nor a silent
+    /// gap, so it never contributes to the `covered` numerator.
+    excluded_by: []const []const u8 = &.{},
 };
 
 /// Structured coverage of one catalog: every control in catalog order plus the
@@ -228,6 +233,10 @@ pub const Coverage = struct {
     controls: []ControlCoverage,
     total: usize,
     covered: usize,
+    /// Distinct controls declared out of scope by ≥1 published policy. Counted
+    /// separately from `covered`: an exclusion is a documented decision, not
+    /// coverage.
+    excluded: usize = 0,
 };
 
 /// Compute structured coverage: walk `policy_root` (skipping drafts, matching
@@ -242,6 +251,10 @@ pub fn coverage(self: *Self, io: std.Io, taxonomy_key: []const u8, policy_root: 
     // One policy-title list per catalog control, indexed like self.map.
     const lists = try a.alloc(Array([]const u8), self.map.count());
     for (lists) |*l| l.* = .empty;
+
+    // Parallel list of the policies that declare each control out of scope.
+    const excl_lists = try a.alloc(Array([]const u8), self.map.count());
+    for (excl_lists) |*l| l.* = .empty;
 
     var pr = try std.Io.Dir.cwd().openDir(io, policy_root, .{
         .access_sub_paths = true,
@@ -283,34 +296,62 @@ pub fn coverage(self: *Self, io: std.Io, taxonomy_key: []const u8, policy_root: 
             break :blk try a.dupe(u8, path);
         };
 
-        const controls = fm.get(taxonomy_key) orelse continue;
-        if (controls != .array) continue;
-        for (controls.array.items) |control| {
-            if (control != .string) continue;
-            const idx = self.map.getIndex(control.string) orelse continue;
-            // A policy listing the same control twice still counts once.
-            const list = &lists[idx];
-            if (list.items.len > 0 and std.mem.eql(u8, list.items[list.items.len - 1], policy_title)) continue;
-            try list.append(a, policy_title);
+        if (fm.get(taxonomy_key)) |controls| {
+            if (controls == .array) for (controls.array.items) |control| {
+                if (control != .string) continue;
+                const idx = self.map.getIndex(control.string) orelse continue;
+                // A policy listing the same control twice still counts once.
+                const list = &lists[idx];
+                if (list.items.len > 0 and std.mem.eql(u8, list.items[list.items.len - 1], policy_title)) continue;
+                try list.append(a, policy_title);
+            };
+        }
+
+        // Declared scope exclusions (`extra.scope_exclusions: [{ id, reason }]`).
+        // Framework-agnostic ids: only those present in *this* catalog land here,
+        // so an SCF exclusion never shows up in the TSC 2017 coverage. Unknown
+        // ids are ignored (validation flags them separately). Never touches the
+        // coverage numerator — an exclusion is a distinct third state.
+        if (fm.get("extra.scope_exclusions")) |exclusions| {
+            if (exclusions == .array) for (exclusions.array.items) |ex| {
+                if (ex != .object) continue;
+                const id_v = ex.object.get("id") orelse continue;
+                if (id_v != .string) continue;
+                const idx = self.map.getIndex(id_v.string) orelse continue;
+                const list = &excl_lists[idx];
+                // Dedup a policy that lists the same exclusion twice.
+                var seen = false;
+                for (list.items) |existing| {
+                    if (std.mem.eql(u8, existing, policy_title)) {
+                        seen = true;
+                        break;
+                    }
+                }
+                if (!seen) try list.append(a, policy_title);
+            };
         }
     }
 
     var out = try a.alloc(ControlCoverage, self.map.count());
     var covered: usize = 0;
+    var excluded: usize = 0;
     var it = self.map.iterator();
     var i: usize = 0;
     while (it.next()) |entry| : (i += 1) {
         std.mem.sort([]const u8, lists[i].items, {}, lessThanConstString);
+        std.mem.sort([]const u8, excl_lists[i].items, {}, lessThanConstString);
         if (lists[i].items.len > 0) covered += 1;
+        if (excl_lists[i].items.len > 0) excluded += 1;
         out[i] = .{
             .domain = entry.value_ptr.domain,
             .control_id = entry.value_ptr.control_id,
             .control = entry.value_ptr.control,
             .policies = lists[i].items,
+            .excluded_by = excl_lists[i].items,
         };
     }
 
-    return .{ .controls = out, .total = out.len, .covered = covered };
+    return .{ .controls = out, .total = out.len, .covered = covered, .excluded = excluded };
 }
 
 fn lessThanString(_: void, lhs: []u8, rhs: []u8) bool {

--- a/src/controls.zig
+++ b/src/controls.zig
@@ -35,6 +35,7 @@ const praxis_join = @import("praxis_join");
 const Config = @import("config").Config;
 const u = @import("utils");
 const mvzr = @import("mvzr");
+const annex = @import("control_annex");
 
 const ctrllog = std.log.scoped(.controls);
 
@@ -79,6 +80,11 @@ pub const ControlJoin = struct {
     /// is absent — the resolver then omits the title clause and validation skips
     /// the unknown-id check.
     catalog: ?reports,
+    /// TSC 2017 (SOC 2) catalog instance, or null when `data/tsc2017.json` is
+    /// absent. Only the control-coverage annex reads it (to title tagged
+    /// `taxonomies.TSC2017` criteria); footnote resolution and validation are
+    /// SCF-only.
+    tsc_catalog: ?reports,
     /// praxis spine membership, or null when no join file is configured.
     join: ?praxis_join.PraxisJoin,
     /// The non-draft policies, queried for covering-policy titles.
@@ -98,6 +104,7 @@ pub const ControlJoin = struct {
         io: std.Io,
         alloc: Allocator,
         catalog_path: ?[]const u8,
+        tsc_catalog_path: ?[]const u8,
         join_path: ?[]const u8,
         policy_paths: []const []const u8,
     ) !ControlJoin {
@@ -108,6 +115,20 @@ pub const ControlJoin = struct {
                 ctrllog.info(
                     "control catalog '{s}' unavailable ({s}); footnotes will omit control titles",
                     .{ cp, @errorName(err) },
+                );
+                break :blk null;
+            };
+        }
+
+        // TSC 2017 catalog for the annex; degrades to null exactly like the SCF
+        // catalog (the annex then shows tagged criteria by id alone).
+        var tsc_catalog: ?reports = null;
+        errdefer if (tsc_catalog) |*c| c.deinit();
+        if (tsc_catalog_path) |tp| {
+            tsc_catalog = reports.init(io, alloc, tp) catch |err| blk: {
+                ctrllog.info(
+                    "TSC 2017 catalog '{s}' unavailable ({s}); the coverage annex will omit criterion titles",
+                    .{ tp, @errorName(err) },
                 );
                 break :blk null;
             };
@@ -147,11 +168,12 @@ pub const ControlJoin = struct {
             };
         }
 
-        return .{ .catalog = catalog, .join = join, .library = library };
+        return .{ .catalog = catalog, .tsc_catalog = tsc_catalog, .join = join, .library = library };
     }
 
     pub fn deinit(self: *ControlJoin) void {
         if (self.catalog) |*c| c.deinit();
+        if (self.tsc_catalog) |*c| c.deinit();
         if (self.join) |*j| j.deinit();
         self.library.deinit();
     }
@@ -165,6 +187,33 @@ pub const ControlJoin = struct {
     fn resolveThunk(ctx: ?*anyopaque, alloc: Allocator, label: []const u8) anyerror!?[]const u8 {
         const self: *const ControlJoin = @ptrCast(@alignCast(ctx.?));
         return self.resolveFootnote(alloc, label);
+    }
+
+    /// A `control_annex.Provider` bound to this join, for the PDF control-coverage
+    /// annex. Answers the one global lookup (control/criterion title) that
+    /// `typst.zig` cannot do itself; the per-policy tags come from the frontmatter
+    /// typst already parses. The annex is praxis-agnostic — spine membership is an
+    /// optional overlay (web badges + join.json), not part of the core table. The
+    /// returned provider borrows `self`; it must not outlive the `ControlJoin`.
+    /// Read-only, so safe to share (by value) across the concurrent compile tasks.
+    pub fn annexProvider(self: *const ControlJoin) annex.Provider {
+        return .{
+            .ctx = @constCast(self),
+            .lookupFn = annexLookupThunk,
+        };
+    }
+
+    fn annexLookupThunk(ctx: ?*anyopaque, framework: annex.Framework, id: []const u8) annex.Info {
+        const self: *const ControlJoin = @ptrCast(@alignCast(ctx.?));
+        const cat: ?*const reports = switch (framework) {
+            .scf => if (self.catalog) |*c| c else null,
+            .tsc2017 => if (self.tsc_catalog) |*c| c else null,
+        };
+        const title: ?[]const u8 = if (cat) |c| blk: {
+            const ctrl = c.map.get(id) orelse break :blk null;
+            break :blk std.mem.trim(u8, ctrl.control, " ");
+        } else null;
+        return .{ .title = title };
     }
 
     /// Markdown definition body for a control footnote, or null when `label` is
@@ -257,6 +306,13 @@ pub const ControlJoin = struct {
     ///
     /// Unknown-id checks are skipped when no catalog is loaded (nothing to check
     /// against). Non-control footnote references are ignored here.
+    ///
+    /// Scope exclusions (`extra.scope_exclusions`) are also validated: a
+    /// malformed/unknown id or a missing reason is critical, an id both covered
+    /// and excluded by the same policy is critical, and a control excluded here
+    /// but covered by *another* policy is an advisory (a legitimate governance
+    /// tension for praxis to adjudicate — the repo-wide view comes from the
+    /// shared library).
     pub fn reviewControlRefs(self: *const ControlJoin, io: std.Io, alloc: Allocator, path: []const u8) Config.IssueKind {
         const content = std.Io.Dir.cwd().readFileAlloc(io, path, alloc, .limited(u.max_policy_bytes)) catch |err| {
             ctrllog.warn("{s}: cannot read for control validation: {s}", .{ path, @errorName(err) });
@@ -268,6 +324,7 @@ pub const ControlJoin = struct {
         worst = maxKind(worst, self.reviewTaxonomy(alloc, path, content));
         worst = maxKind(worst, self.reviewShortcodes(path, content));
         worst = maxKind(worst, self.reviewDanglingRefs(alloc, path, content));
+        worst = maxKind(worst, self.reviewExclusions(alloc, path, content));
         return worst;
     }
 
@@ -365,6 +422,111 @@ pub const ControlJoin = struct {
                 .{ path, label, label },
             );
             worst = .critical;
+        }
+        return worst;
+    }
+
+    /// `extra.scope_exclusions` validation. Each entry is `{ id, reason }`. An
+    /// exclusion is a documented "we do not do X", so it must never read as
+    /// coverage — the rules keep exclusions well-formed and surface the
+    /// governance tension when a control is both covered and excluded:
+    ///
+    ///   * a malformed or (with a catalog) unknown id → critical;
+    ///   * a missing/empty `reason` → critical;
+    ///   * an id in *this* policy's `taxonomies.SCF` and its exclusions → critical
+    ///     (a policy cannot both claim and disclaim the same control); and
+    ///   * an id excluded here but covered by *another* published policy →
+    ///     advisory (repo-wide view via the shared library).
+    fn reviewExclusions(self: *const ControlJoin, alloc: Allocator, path: []const u8, content: []const u8) Config.IssueKind {
+        var fm = zigmark.Frontmatter.initFromMarkdown(alloc, content) catch return .none;
+        defer fm.deinit();
+
+        const ex_v = fm.get("extra.scope_exclusions") orelse return .none;
+        if (ex_v != .array) {
+            ctrllog.warn("{s}: extra.scope_exclusions must be a list of {{ id, reason }} entries", .{path});
+            return .critical;
+        }
+
+        // This policy's own SCF tags, for the same-policy cover+exclude check.
+        const scf_v = fm.get("taxonomies.SCF");
+        const own_title: []const u8 = blk: {
+            if (fm.get("title")) |t| {
+                if (t == .string) break :blk t.string;
+            }
+            break :blk path;
+        };
+
+        var worst: Config.IssueKind = .none;
+        for (ex_v.array.items) |item| {
+            if (item != .object) {
+                ctrllog.warn("{s}: each extra.scope_exclusions entry must be a mapping with 'id' and 'reason'", .{path});
+                worst = .critical;
+                continue;
+            }
+            const obj = item.object;
+
+            const id: ?[]const u8 = if (obj.get("id")) |v| (if (v == .string) v.string else null) else null;
+            if (id == null) {
+                ctrllog.warn("{s}: a scope-exclusion entry is missing a string 'id'", .{path});
+                worst = .critical;
+                continue;
+            }
+            const eid = id.?;
+
+            if (!isControlId(eid)) {
+                ctrllog.warn("{s}: malformed scope-exclusion id '{s}' (expected e.g. PES-01)", .{ path, eid });
+                worst = .critical;
+            } else if (self.catalog) |*cat| {
+                if (!cat.map.contains(eid)) {
+                    ctrllog.warn("{s}: unknown scope-exclusion id '{s}' (not in data/scf.json)", .{ path, eid });
+                    worst = .critical;
+                }
+            }
+
+            // A reason is mandatory: an unexplained exclusion is worthless to an
+            // auditor and easy to mistake for an oversight.
+            const reason_ok = blk: {
+                const r = obj.get("reason") orelse break :blk false;
+                if (r != .string) break :blk false;
+                break :blk std.mem.trim(u8, r.string, " \t\r\n").len > 0;
+            };
+            if (!reason_ok) {
+                ctrllog.warn("{s}: scope-exclusion '{s}' needs a non-empty 'reason'", .{ path, eid });
+                worst = .critical;
+            }
+
+            // Same-policy cover+exclude: contradictory.
+            if (scf_v) |sv| {
+                if (sv == .array) {
+                    for (sv.array.items) |t| {
+                        if (t == .string and std.mem.eql(u8, t.string, eid)) {
+                            ctrllog.warn(
+                                "{s}: control '{s}' is listed in both taxonomies.SCF and extra.scope_exclusions — a policy cannot both claim and disclaim a control",
+                                .{ path, eid },
+                            );
+                            worst = .critical;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // Cross-policy cover/exclude conflict → advisory. Only meaningful for
+            // well-formed ids; a covering policy other than this one is the tension.
+            if (isControlId(eid)) {
+                const covering = self.coveringPolicies(alloc, eid) catch &.{};
+                defer alloc.free(covering);
+                for (covering) |title| {
+                    if (!std.mem.eql(u8, title, own_title)) {
+                        ctrllog.warn(
+                            "{s}: control '{s}' is declared out of scope here but covered by '{s}' — praxis should adjudicate this governance tension",
+                            .{ path, eid, title },
+                        );
+                        worst = maxKind(worst, .advisory);
+                        break;
+                    }
+                }
+            }
         }
         return worst;
     }

--- a/src/golden.zig
+++ b/src/golden.zig
@@ -62,12 +62,16 @@ pub fn renderControlFixture(io: std.Io, alloc: std.mem.Allocator) ![]u8 {
         io,
         alloc,
         "src/test/controls_catalog.json",
+        "src/test/controls_tsc_catalog.json",
         "src/test/controls_join.json",
         &.{fixture},
     );
     defer cj.deinit();
 
-    var rendered = try typst.renderWithControls(io, alloc, conf, fixture, cj.resolver());
+    // Pass BOTH the footnote resolver (inline control(...) refs) and the annex
+    // provider (frontmatter framework tags + scope exclusions), so the baseline
+    // exercises the full #164+#165 render path.
+    var rendered = try typst.renderWithControls(io, alloc, conf, fixture, cj.resolver(), cj.annexProvider());
     defer rendered.deinit(alloc);
     return alloc.dupe(u8, rendered.source);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -27,6 +27,7 @@ const writeStamp = @import("utils").writeStamp;
 const audit = @import("audit.zig");
 const diagrams = @import("diagrams.zig");
 const controls = @import("controls");
+const control_annex = @import("control_annex");
 const zigmark = @import("zigmark");
 
 // ---------------------------------------------------------------------------
@@ -459,6 +460,14 @@ fn runBuild(io: std.Io, env: *EnvMap, alloc: Allocator, args: []const [:0]const 
         std.Io.Dir.cwd().access(io, scf_catalog_path, .{}) catch break :blk false;
         break :blk true;
     };
+    // TSC 2017 catalog — only the control-coverage annex reads it (to title
+    // tagged criteria). Absent on sites without SOC 2 data; degrades gracefully.
+    const tsc_catalog_path = try std.fs.path.join(alloc, &.{ config.root, reports.Kind.soc2.catalogFile().? });
+    defer alloc.free(tsc_catalog_path);
+    const tsc_exists = blk: {
+        std.Io.Dir.cwd().access(io, tsc_catalog_path, .{}) catch break :blk false;
+        break :blk true;
+    };
     const join_path: ?[]const u8 = if (config.praxis_join) |rel|
         try std.fs.path.join(alloc, &.{ config.root, rel })
     else
@@ -473,11 +482,13 @@ fn runBuild(io: std.Io, env: *EnvMap, alloc: Allocator, args: []const [:0]const 
         io,
         alloc,
         if (scf_exists) scf_catalog_path else null,
+        if (tsc_exists) tsc_catalog_path else null,
         join_path,
         policy_paths,
     );
     defer control_join.deinit();
     const control_resolver: ?zigmark.footnotes.Resolver = control_join.resolver();
+    const control_annex_provider: ?control_annex.Provider = control_join.annexProvider();
 
     // --- Front-matter validation (pre-flight) ---
     // Warn on incomplete front matter; with --strict, fail on audit-critical
@@ -607,6 +618,7 @@ fn runBuild(io: std.Io, env: *EnvMap, alloc: Allocator, args: []const [:0]const 
             config,
             p.path,
             control_resolver,
+            control_annex_provider,
             stamps_dir_path,
             compile_node,
             &error_mutex,
@@ -929,6 +941,7 @@ fn compileOne(
     config: Config,
     input_path: []const u8,
     resolver: ?zigmark.footnotes.Resolver,
+    annex_provider: ?control_annex.Provider,
     stamps_dir: []const u8,
     progress_node: std.Progress.Node,
     error_mutex: *std.Io.Mutex,
@@ -937,7 +950,7 @@ fn compileOne(
 ) void {
     defer progress_node.completeOne();
 
-    Typst.compile(io, env, alloc, config, input_path, resolver) catch |err| {
+    Typst.compile(io, env, alloc, config, input_path, resolver, annex_provider) catch |err| {
         error_mutex.lockUncancelable(io);
         defer error_mutex.unlock(io);
         error_count.* += 1;

--- a/src/report_render.zig
+++ b/src/report_render.zig
@@ -78,6 +78,18 @@ pub fn renderCoverage(alloc: Allocator, cov: report.Coverage, opts: ReportOpts) 
         "Coverage means a published policy lists the control in its front-matter " ++
             "taxonomy. Draft policies are excluded, matching the website.\n",
     );
+    // Scope exclusions are a distinct third state: a documented "we do not do
+    // this", counted apart from coverage. Emitted only when present, so reports
+    // with no exclusions (e.g. SOC 2, whose criteria are never excluded by the
+    // SCF-id exclusion list) stay byte-identical.
+    if (cov.excluded > 0) {
+        try w.print(
+            "\n*{d}* control(s) are declared out of scope by a published policy; " ++
+                "an exclusion is a documented decision not to apply a control and is " ++
+                "counted separately from coverage.\n",
+            .{cov.excluded},
+        );
+    }
 
     // ── Per-domain sections (catalog order; domains are contiguous runs) ────
     var i: usize = 0;
@@ -109,11 +121,24 @@ pub fn renderCoverage(alloc: Allocator, cov: report.Coverage, opts: ReportOpts) 
             try w.writeAll("], [");
             try typst.writeEscaped(w, std.mem.trim(u8, c.control, " "));
             try w.writeAll("], [");
-            if (c.policies.len == 0) {
+            if (c.policies.len == 0 and c.excluded_by.len == 0) {
                 try w.writeAll("\u{2014}");
-            } else for (c.policies, 0..) |p, pi| {
-                if (pi > 0) try w.writeAll("; ");
-                try typst.writeEscaped(w, p);
+            } else {
+                for (c.policies, 0..) |p, pi| {
+                    if (pi > 0) try w.writeAll("; ");
+                    try typst.writeEscaped(w, p);
+                }
+                // Distinct marker for a declared-out-of-scope control, appended
+                // after any covering policies (a control can, in a governance
+                // conflict, be both covered and excluded).
+                if (c.excluded_by.len > 0) {
+                    if (c.policies.len > 0) try w.writeAll("; ");
+                    try w.writeAll("out of scope: ");
+                    for (c.excluded_by, 0..) |p, pi| {
+                        if (pi > 0) try w.writeAll(", ");
+                        try typst.writeEscaped(w, p);
+                    }
+                }
             }
             try w.writeAll("],\n");
         }

--- a/src/test.zig
+++ b/src/test.zig
@@ -198,7 +198,7 @@ test "pdf rendering" {
     // test_policy.md contains a mermaid diagram: unlike the pandoc pipeline
     // (which needed Chrome for mermaid-filter), pozeiden renders it in-process
     // so the full pipeline works even inside the Nix sandbox.
-    typst.compile(io, &env, tst.allocator, conf, "src/test/test_policy.md", null) catch |e| {
+    typst.compile(io, &env, tst.allocator, conf, "src/test/test_policy.md", null, null) catch |e| {
         std.debug.print("Test Policy Typst Call Failed! \nConfig:{f}\n", .{conf});
         return e;
     };
@@ -1241,9 +1241,16 @@ test "coverage: corrected numerator, dedup, draft exclusion, unknown IDs" {
     try tst.expectEqualStrings("GOV-02", cov.controls[1].control_id);
     try tst.expectEqual(@as(usize, 2), cov.controls[1].policies.len);
 
-    // GOV-03 is only tagged by the draft policy: excluded.
+    // GOV-03 is only tagged by the draft policy: uncovered. It is also declared
+    // out of scope by Alpha (extra.scope_exclusions), so it is in the third
+    // state — excluded but not covered. The exclusion never inflates `covered`.
     try tst.expectEqualStrings("GOV-03", cov.controls[2].control_id);
     try tst.expectEqual(@as(usize, 0), cov.controls[2].policies.len);
+    try tst.expectEqual(@as(usize, 1), cov.excluded);
+    try tst.expectEqual(@as(usize, 1), cov.controls[2].excluded_by.len);
+    try tst.expectEqualStrings("Alpha Security Policy", cov.controls[2].excluded_by[0]);
+    // A covered control carries no exclusion.
+    try tst.expectEqual(@as(usize, 0), cov.controls[0].excluded_by.len);
 }
 
 test "collectReviewRows: sorted, statuses, missing fields" {
@@ -1378,6 +1385,28 @@ test "audit bundle: manifest hashes, newest revision, coverage export" {
         try tst.expectEqualStrings("SCF", scf.get("id").?.string);
         try tst.expect(scf.get("covered").?.integer >= 1);
         try tst.expect(scf.get("total").?.integer >= 1468);
+
+        // Additive per-control excluded_by (#165), schema string unchanged. The
+        // fixture policy declares PES-01 out of scope, so that control's
+        // excluded_by lists the policy title; a covered control (HRS-05) has an
+        // empty excluded_by. Every control carries the key (additive schema).
+        var saw_pes01 = false;
+        var saw_hrs05 = false;
+        for (scf.get("controls").?.array.items) |cv| {
+            const c = cv.object;
+            const cid = c.get("control_id").?.string;
+            const excl = c.get("excluded_by").?.array.items;
+            if (std.mem.eql(u8, cid, "PES-01")) {
+                saw_pes01 = true;
+                try tst.expectEqual(@as(usize, 1), excl.len);
+                try tst.expectEqualStrings("Test Policy", excl[0].string);
+            } else if (std.mem.eql(u8, cid, "HRS-05")) {
+                saw_hrs05 = true;
+                try tst.expectEqual(@as(usize, 0), excl.len);
+            }
+        }
+        try tst.expect(saw_pes01);
+        try tst.expect(saw_hrs05);
     }
 }
 
@@ -1454,6 +1483,7 @@ fn fixtureControlJoin(alloc: Allocator) !controls.ControlJoin {
         io,
         alloc,
         "src/test/controls_catalog.json",
+        "src/test/controls_tsc_catalog.json",
         "src/test/controls_join.json",
         &.{"src/test/test_policy_controls.md"},
     );
@@ -1511,6 +1541,7 @@ test "controls: resolveFootnote — no praxis join omits the spine clause" {
         io,
         alloc,
         "src/test/controls_catalog.json",
+        null, // no TSC catalog
         null, // no join configured
         &.{"src/test/test_policy_controls.md"},
     );
@@ -1529,6 +1560,7 @@ test "controls: resolveFootnote — no catalog omits the title clause" {
         io,
         alloc,
         null, // no catalog
+        null, // no TSC catalog
         "src/test/controls_join.json",
         &.{"src/test/test_policy_controls.md"},
     );
@@ -1623,4 +1655,144 @@ test "controls: reviewControlRefs — a control-shaped dangling raw ref is criti
     defer alloc.free(p);
 
     try tst.expectEqual(config.IssueKind.critical, cj.reviewControlRefs(io, alloc, p));
+}
+
+test "controls: annexProvider resolves catalog titles (praxis-agnostic)" {
+    const alloc = tst.allocator;
+    var cj = try fixtureControlJoin(alloc);
+    defer cj.deinit();
+
+    const prov = cj.annexProvider();
+
+    // SCF: title from the catalog. The annex carries no praxis-spine column —
+    // spine membership is an optional overlay (web badges + join.json), not
+    // part of this core table.
+    const iac = prov.lookup(.scf, "IAC-01");
+    try tst.expectEqualStrings("Identity & Access Management", iac.title.?);
+    const dch = prov.lookup(.scf, "DCH-01");
+    try tst.expectEqualStrings("Data Protection", dch.title.?);
+
+    // TSC 2017: title from the TSC catalog.
+    const cc = prov.lookup(.tsc2017, "CC1.1");
+    try tst.expectEqualStrings("Integrity and Ethics", cc.title.?);
+
+    // Unknown id → null title (annex shows the id alone).
+    try tst.expect(prov.lookup(.scf, "ZZZ-99").title == null);
+}
+
+test "controls: reviewControlRefs — a scope exclusion missing a reason is critical" {
+    const alloc = tst.allocator;
+    var cj = try fixtureControlJoin(alloc);
+    defer cj.deinit();
+
+    var tmp = tst.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmpAbsPath(alloc, &tmp);
+    defer alloc.free(tmp_path);
+
+    // NET-02 is a valid catalog id not covered by the library policy, so the
+    // only problem is the missing reason (isolates the rule from the advisory).
+    const md =
+        \\---
+        \\title: "No Reason"
+        \\extra:
+        \\  scope_exclusions:
+        \\    - id: NET-02
+        \\---
+        \\Body.
+    ;
+    try tmp.dir.writeFile(io, .{ .sub_path = "no_reason.md", .data = md });
+    const p = try std.fs.path.join(alloc, &.{ tmp_path, "no_reason.md" });
+    defer alloc.free(p);
+
+    try tst.expectEqual(config.IssueKind.critical, cj.reviewControlRefs(io, alloc, p));
+}
+
+test "controls: reviewControlRefs — an unknown scope-exclusion id is critical" {
+    const alloc = tst.allocator;
+    var cj = try fixtureControlJoin(alloc);
+    defer cj.deinit();
+
+    var tmp = tst.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmpAbsPath(alloc, &tmp);
+    defer alloc.free(tmp_path);
+
+    // GOV-99 is well-formed but not in the fixture catalog.
+    const md =
+        \\---
+        \\title: "Unknown Exclusion"
+        \\extra:
+        \\  scope_exclusions:
+        \\    - id: GOV-99
+        \\      reason: "x"
+        \\---
+        \\Body.
+    ;
+    try tmp.dir.writeFile(io, .{ .sub_path = "unknown_excl.md", .data = md });
+    const p = try std.fs.path.join(alloc, &.{ tmp_path, "unknown_excl.md" });
+    defer alloc.free(p);
+
+    try tst.expectEqual(config.IssueKind.critical, cj.reviewControlRefs(io, alloc, p));
+}
+
+test "controls: reviewControlRefs — same-policy cover+exclude is critical" {
+    const alloc = tst.allocator;
+    var cj = try fixtureControlJoin(alloc);
+    defer cj.deinit();
+
+    var tmp = tst.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmpAbsPath(alloc, &tmp);
+    defer alloc.free(tmp_path);
+
+    // DCH-01 is both claimed (taxonomies.SCF) and disclaimed (scope_exclusions).
+    const md =
+        \\---
+        \\title: "Contradiction"
+        \\taxonomies:
+        \\  SCF:
+        \\    - DCH-01
+        \\extra:
+        \\  scope_exclusions:
+        \\    - id: DCH-01
+        \\      reason: "x"
+        \\---
+        \\Body.
+    ;
+    try tmp.dir.writeFile(io, .{ .sub_path = "contradiction.md", .data = md });
+    const p = try std.fs.path.join(alloc, &.{ tmp_path, "contradiction.md" });
+    defer alloc.free(p);
+
+    try tst.expectEqual(config.IssueKind.critical, cj.reviewControlRefs(io, alloc, p));
+}
+
+test "controls: reviewControlRefs — excluding a control another policy covers is advisory" {
+    const alloc = tst.allocator;
+    var cj = try fixtureControlJoin(alloc);
+    defer cj.deinit();
+
+    var tmp = tst.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmpAbsPath(alloc, &tmp);
+    defer alloc.free(tmp_path);
+
+    // IAC-01 is covered by the library policy ("Access Control Test Policy") but
+    // declared out of scope here — a legitimate governance tension, so advisory
+    // (not critical). The exclusion is otherwise well-formed.
+    const md =
+        \\---
+        \\title: "Excludes A Covered Control"
+        \\extra:
+        \\  scope_exclusions:
+        \\    - id: IAC-01
+        \\      reason: "Handled by the parent entity."
+        \\---
+        \\Body.
+    ;
+    try tmp.dir.writeFile(io, .{ .sub_path = "cross_conflict.md", .data = md });
+    const p = try std.fs.path.join(alloc, &.{ tmp_path, "cross_conflict.md" });
+    defer alloc.free(p);
+
+    try tst.expectEqual(config.IssueKind.advisory, cj.reviewControlRefs(io, alloc, p));
 }

--- a/src/test/controls_tsc_catalog.json
+++ b/src/test/controls_tsc_catalog.json
@@ -1,0 +1,12 @@
+[
+  {
+    "domain": "CC1",
+    "control_id": "CC1.1",
+    "control": "Integrity and Ethics"
+  },
+  {
+    "domain": "CC6",
+    "control_id": "CC6.1",
+    "control": "Logical Access Controls"
+  }
+]

--- a/src/test/test_policy.md
+++ b/src/test/test_policy.md
@@ -18,6 +18,9 @@ taxonomies:
 extra:
   owner: SC2
   last_reviewed: 2025-02-24
+  scope_exclusions:
+    - id: PES-01
+      reason: "We operate no physical facilities; all infrastructure is colocated with certified providers."
   major_revisions:
     - date: 2025-06-24
       description: Demo revision.

--- a/src/test/test_policy_controls.md
+++ b/src/test/test_policy_controls.md
@@ -7,9 +7,15 @@ taxonomies:
   SCF:
     - IAC-01
     - DCH-01
+  TSC2017:
+    - CC1.1
+    - CC6.1
 extra:
   owner: SC2
   last_reviewed: 2025-02-24
+  scope_exclusions:
+    - id: NET-02
+      reason: "All network defenses are operated by our colocation provider under a shared-responsibility model."
   major_revisions:
     - date: 2025-06-24
       description: Initial version.

--- a/src/typst.zig
+++ b/src/typst.zig
@@ -29,6 +29,7 @@ const u = @import("utils");
 const zigmark = @import("zigmark");
 const pozeiden = @import("pozeiden");
 const fonts = @import("fonts.zig");
+const annex = @import("control_annex");
 
 const EnvMap = std.process.Environ.Map;
 
@@ -133,8 +134,12 @@ pub fn compile(
     /// footnote references undefined. Read-only, so it is safe to copy into each
     /// concurrent compile task.
     resolver: ?zigmark.footnotes.Resolver,
+    /// Control-coverage annex provider (from `controls.ControlJoin`), or null to
+    /// omit the annex entirely (byte-identical to the pre-#165 output). Also
+    /// read-only and copy-safe across the compile tasks.
+    annex_provider: ?annex.Provider,
 ) !void {
-    var rendered = try renderWithControls(io, alloc, config, input_file, resolver);
+    var rendered = try renderWithControls(io, alloc, config, input_file, resolver, annex_provider);
     defer rendered.deinit(alloc);
 
     try compileSource(io, env, alloc, config, rendered.source, std.fs.path.basename(input_file), rendered.pdf_name);
@@ -229,7 +234,7 @@ pub fn render(
     config: Config,
     input_file: []const u8,
 ) !Rendered {
-    return renderWithControls(io, alloc, config, input_file, null);
+    return renderWithControls(io, alloc, config, input_file, null, null);
 }
 
 /// As `render`, but when `resolver` is non-null every undefined footnote
@@ -244,6 +249,7 @@ pub fn renderWithControls(
     config: Config,
     input_file: []const u8,
     resolver: ?zigmark.footnotes.Resolver,
+    annex_provider: ?annex.Provider,
 ) !Rendered {
     log.debug("Processing markdown file: {s}\n", .{input_file});
 
@@ -392,6 +398,11 @@ pub fn renderWithControls(
     });
     try zigmark.renderTypstWithMermaid(alloc, &aw.writer, doc, &renderMermaid);
     try writeVersionHistory(&aw.writer, &raw_fm);
+    // Control Coverage annex: frontmatter framework tags + scope exclusions have
+    // no in-text anchor, so they render as an end-of-document annex rather than
+    // as (anchorless) footnotes. Emitted only when a provider is supplied — the
+    // golden default path (null) stays byte-identical.
+    if (annex_provider) |p| try writeControlAnnex(&aw.writer, &raw_fm, p);
 
     const typ_src = try aw.toOwnedSlice();
     errdefer alloc.free(typ_src);
@@ -825,6 +836,130 @@ fn writeVersionHistory(writer: anytype, fm: *zigmark.Frontmatter) !void {
     try writer.writeAll(")\n");
 }
 
+// ── Control Coverage annex ──────────────────────────────────────────────────
+
+/// The frontmatter array under `key`, or null when it is absent or not a list.
+fn annexArray(fm: *zigmark.Frontmatter, key: []const u8) ?[]std.json.Value {
+    const v = fm.get(key) orelse return null;
+    return switch (v) {
+        .array => |a| a.items,
+        else => null,
+    };
+}
+
+/// Count the `.string` entries in a frontmatter array (the tagged ids).
+fn countStrings(items: ?[]std.json.Value) usize {
+    var n: usize = 0;
+    if (items) |list| for (list) |it| {
+        if (it == .string) n += 1;
+    };
+    return n;
+}
+
+/// Count well-formed scope-exclusion entries (`{ id: str, reason: str }`).
+fn countExclusions(items: ?[]std.json.Value) usize {
+    var n: usize = 0;
+    if (items) |list| for (list) |it| {
+        if (it != .object) continue;
+        const id = it.object.get("id") orelse continue;
+        if (id != .string) continue;
+        n += 1;
+    };
+    return n;
+}
+
+/// Append a "Control Coverage" annex: one table per tagged framework present in
+/// the frontmatter (SCF and TSC 2017 both show ID | Control/Criterion) plus a
+/// "Declared out of scope" subsection listing each `extra.scope_exclusions` id
+/// with its reason. Titles come from `provider`; the tag lists come straight
+/// from `fm`. Praxis-spine status is intentionally absent — it's an optional
+/// overlay (web badges + join.json), not part of this core table. Emits nothing
+/// when the policy has no framework tags and no exclusions (output stays
+/// byte-identical to a policy without an annex).
+fn writeControlAnnex(writer: anytype, fm: *zigmark.Frontmatter, provider: annex.Provider) !void {
+    const scf = annexArray(fm, "taxonomies.SCF");
+    const tsc = annexArray(fm, "taxonomies.TSC2017");
+    const exclusions = annexArray(fm, "extra.scope_exclusions");
+
+    const scf_n = countStrings(scf);
+    const tsc_n = countStrings(tsc);
+    const excl_n = countExclusions(exclusions);
+    if (scf_n == 0 and tsc_n == 0 and excl_n == 0) return;
+
+    try writer.writeAll("\n#pagebreak()\n= Control Coverage\n\n");
+
+    if (scf_n > 0) {
+        try writer.writeAll("== SCF\n\n");
+        try writer.writeAll(
+            "#table(\n" ++
+                "  columns: (auto, 1fr),\n" ++
+                "  align: (left, left),\n" ++
+                "  table.header(\n" ++
+                "    [*ID*], [*Control*],\n" ++
+                "  ),\n",
+        );
+        for (scf.?) |item| {
+            if (item != .string) continue;
+            const id = item.string;
+            const info = provider.lookup(.scf, id);
+            try writer.writeAll("  [");
+            try writeEscaped(writer, id);
+            try writer.writeAll("], [");
+            if (info.title) |t| try writeEscaped(writer, t) else try writer.writeAll("\u{2014}");
+            try writer.writeAll("],\n");
+        }
+        try writer.writeAll(")\n\n");
+    }
+
+    if (tsc_n > 0) {
+        try writer.writeAll("== TSC 2017\n\n");
+        try writer.writeAll(
+            "#table(\n" ++
+                "  columns: (auto, 1fr),\n" ++
+                "  align: (left, left),\n" ++
+                "  table.header(\n" ++
+                "    [*ID*], [*Criterion*],\n" ++
+                "  ),\n",
+        );
+        for (tsc.?) |item| {
+            if (item != .string) continue;
+            const id = item.string;
+            const info = provider.lookup(.tsc2017, id);
+            try writer.writeAll("  [");
+            try writeEscaped(writer, id);
+            try writer.writeAll("], [");
+            if (info.title) |t| try writeEscaped(writer, t) else try writer.writeAll("\u{2014}");
+            try writer.writeAll("],\n");
+        }
+        try writer.writeAll(")\n\n");
+    }
+
+    if (excl_n > 0) {
+        try writer.writeAll("== Declared out of scope\n\n");
+        try writer.writeAll(
+            "#table(\n" ++
+                "  columns: (auto, 1fr),\n" ++
+                "  align: (left, left),\n" ++
+                "  table.header(\n" ++
+                "    [*ID*], [*Reason*],\n" ++
+                "  ),\n",
+        );
+        for (exclusions.?) |item| {
+            if (item != .object) continue;
+            const id_v = item.object.get("id") orelse continue;
+            if (id_v != .string) continue;
+            try writer.writeAll("  [");
+            try writeEscaped(writer, id_v.string);
+            try writer.writeAll("], [");
+            if (item.object.get("reason")) |r| {
+                if (r == .string) try writeEscaped(writer, r.string);
+            }
+            try writer.writeAll("],\n");
+        }
+        try writer.writeAll(")\n");
+    }
+}
+
 // ── typst subprocess ──────────────────────────────────────────────────────────
 
 /// Spawn `typst compile --root <root> --font-path <bundled> <input.typ>
@@ -1010,6 +1145,7 @@ pub fn main(init: std.process.Init) !void {
 
     if (res.args.input) |w| {
         log.info("Input File: {s}\n", .{w});
-        try compile(io, env, alloc, config, w);
+        // Standalone CLI: no control join, so no footnote resolver and no annex.
+        try compile(io, env, alloc, config, w, null, null);
     } else return error.InputFileNotProvided;
 }

--- a/templates/SCF/list.html
+++ b/templates/SCF/list.html
@@ -26,6 +26,13 @@
 {% if praxis_path %}{% set praxis = load_data(path=praxis_path, required=false) %}{% endif %}
 {% set has_praxis = praxis and praxis.ids %}
 
+{# Policy pages, for the out-of-scope third state below: a control with no
+   covering policy may still be *deliberately* excluded by one. Fetched once;
+   the per-control scan of extra.scope_exclusions is a bounded nested loop. #}
+{% set_global policy_pages = [] %}
+{% set policy_section = get_section(path="policies/_index.md") %}
+{% if policy_section %}{% set_global policy_pages = policy_section.pages %}{% endif %}
+
 {# Coverage = distinct data-file control_ids with >=1 mapped policy, over the
    total number of distinct control_ids. Counting `tax.items | length` (taxonomy
    terms used) over `data | length` (data rows) mismatched both ends: a typo'd
@@ -114,7 +121,25 @@
         {% endfor %}
       </ul>
       {% else %}
+      {# Third state: uncovered, but a policy may declare it out of scope. #}
+      {% set_global excluding_pages = [] %}
+      {% for pp_page in policy_pages %}
+        {% if pp_page.extra.scope_exclusions %}
+          {% for ex in pp_page.extra.scope_exclusions %}
+            {% if ex.id == control.control_id %}
+              {% set_global excluding_pages = excluding_pages | concat(with=pp_page) %}
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+      {% endfor %}
+      {% if excluding_pages | length > 0 %}
+      <div class="declared-out-of-scope">
+        Declared out of scope by
+        {% for ep in excluding_pages %}<a href="{{ ep.permalink | safe }}">{{ ep.title }}</a>{% if not loop.last %}, {% endif %}{% endfor %}
+      </div>
+      {% else %}
       <div class="no-policies">No policies mapped to {{ control.control_id }}</div>
+      {% endif %}
       {% endif %}
     </div>
     {% endfor %}

--- a/templates/partials/scope-exclusions.html
+++ b/templates/partials/scope-exclusions.html
@@ -1,0 +1,25 @@
+{#- "Declared Out of Scope" card for a policy page. Renders the policy's
+    extra.scope_exclusions ({ id, reason }) — each id linked to the SCF report
+    anchor (like the satisfies tags) when a report page is configured, plus the
+    stated reason. Deliberately styled apart from Framework Coverage: an
+    exclusion is a documented "we do not do this", never coverage. -#}
+{%- set pp = config.extra.policypress -%}
+{%- set scf_report = pp.scf_report_page | default(value="") -%}
+{%- set exclusions = page.extra.scope_exclusions | default(value=[]) -%}
+{%- if exclusions | length > 0 -%}
+<div class="scope-exclusions">
+  <span class="scope-exclusions-label">Declared Out of Scope</span>
+  <ul class="scope-exclusions-list">
+    {% for ex in exclusions %}
+    <li class="scope-exclusion">
+      {%- if scf_report -%}
+      <a class="scope-exclusion-id" href="{{ get_url(path=scf_report) | safe }}#{{ ex.id }}">{{ ex.id }}</a>
+      {%- else -%}
+      <span class="scope-exclusion-id">{{ ex.id }}</span>
+      {%- endif -%}
+      <span class="scope-exclusion-reason">{{ ex.reason }}</span>
+    </li>
+    {% endfor %}
+  </ul>
+</div>
+{%- endif -%}

--- a/templates/policies/page.html
+++ b/templates/policies/page.html
@@ -110,6 +110,7 @@ reverse %}
 
       {%- include "partials/revisions.html" -%}
       {%- include "partials/satisfies.html" -%}
+      {%- include "partials/scope-exclusions.html" -%}
 
       {% if config.extra.edit_page %}
       {{ macros_edit_page::docs_edit_page(current_path=current_path) }}

--- a/tests/golden/report_scf.typ
+++ b/tests/golden/report_scf.typ
@@ -95,6 +95,8 @@
 
 Coverage means a published policy lists the control in its front-matter taxonomy. Draft policies are excluded, matching the website.
 
+*1* control(s) are declared out of scope by a published policy; an exclusion is a documented decision not to apply a control and is counted separately from coverage.
+
 = Governance
 
 2 of 3 controls covered.
@@ -107,7 +109,7 @@ Coverage means a published policy lists the control in its front-matter taxonomy
   ),
   [GOV-01], [Security Governance Program], [Alpha Security Policy; Bravo Handling Policy],
   [GOV-02], [Publishing \*Security\* \[Documentation\] \#with \$pecials], [Alpha Security Policy; Charlie \*Escaping\* \[Policy\] \#1],
-  [GOV-03], [Periodic Review], [—],
+  [GOV-03], [Periodic Review], [out of scope: Alpha Security Policy],
 )
 
 = Human Resources

--- a/tests/golden/test_policy_controls.typ
+++ b/tests/golden/test_policy_controls.typ
@@ -116,3 +116,41 @@ All data is classified and protected #footnote[DCH-01 — Data Protection. praxi
   [Ada Byrne],
   [Ada Byrne],
 )
+
+#pagebreak()
+= Control Coverage
+
+== SCF
+
+#table(
+  columns: (auto, 1fr),
+  align: (left, left),
+  table.header(
+    [*ID*], [*Control*],
+  ),
+  [IAC-01], [Identity & Access Management],
+  [DCH-01], [Data Protection],
+)
+
+== TSC 2017
+
+#table(
+  columns: (auto, 1fr),
+  align: (left, left),
+  table.header(
+    [*ID*], [*Criterion*],
+  ),
+  [CC1.1], [Integrity and Ethics],
+  [CC6.1], [Logical Access Controls],
+)
+
+== Declared out of scope
+
+#table(
+  columns: (auto, 1fr),
+  align: (left, left),
+  table.header(
+    [*ID*], [*Reason*],
+  ),
+  [NET-02], [All network defenses are operated by our colocation provider under a shared-responsibility model.],
+)

--- a/tests/report-fixtures/policies/pol_a.md
+++ b/tests/report-fixtures/policies/pol_a.md
@@ -12,6 +12,9 @@ taxonomies:
 extra:
   owner: Security Team
   last_reviewed: 2025-12-01
+  scope_exclusions:
+    - id: GOV-03
+      reason: "Periodic review is handled by the parent entity's governance program."
   major_revisions:
     - date: 2025-12-01
       description: Second revision.


### PR DESCRIPTION
Implements subissue #165 (section B4 of the #127 plan): the `extra.scope_exclusions` frontmatter pattern, end to end. A policy can now record "we deliberately do not do X" as a validated `{ id, reason }` list — an auditable third state that is **never** counted as coverage.

## Scope

- **Validation** (`controls.reviewControlRefs`, folded into the `--strict` preflight): a malformed/unknown exclusion id, a missing/empty `reason`, and an id listed in both `taxonomies.SCF` and `scope_exclusions` of the same policy are **critical**; a control excluded here but covered by *another* published policy is an **advisory** (a legitimate governance tension). Cross-policy conflict uses the repo-wide `ControlJoin` library.
- **Coverage engine** (`control_report.zig`): `ControlCoverage.excluded_by`, `Coverage.excluded`. The covered numerator is unchanged; excluded ≠ covered ≠ uncovered.
- **PDF — Control Coverage annex** (`typst.writeControlAnnex`, after the version history): one table per tagged framework — **SCF** = ID | Control | praxis (the praxis column only when a join is configured); **TSC 2017** = ID | Criterion — plus a **Declared out of scope** subsection with reasons. Emitted only when a policy has tags/exclusions; null-context renders stay byte-identical.
- **Coverage report PDF** (`report_render.renderCoverage`): excluded controls marked distinctly + an "N declared out of scope" summary line (only when > 0).
- **Web**: new `templates/partials/scope-exclusions.html` "Declared Out of Scope" card (included from the policy page after `satisfies`), and a third state on the SCF report — an uncovered-but-excluded control shows "Declared out of scope by \<policy\>" instead of "No policies mapped".
- **Audit** `coverage.json`/`coverage.csv`: additive per-control `excluded_by`. **Schema string is unchanged** (`policypress/audit-coverage/v1`) — praxis exact-matches it and ignores unknown keys.
- **Demo + docs**: `content/policies/physical-security-exclusion.md` (covers AST-01/AST-02 + TSC CC6.4 normally, excludes PES-01 [in the join spine] and PES-04); `content/guides/adding-a-policy.md` field-reference row + a "Declaring controls out of scope" section noting unknown ids now fail `--strict`.

## Module-cycle note

`typst.zig` must not import `controls`. Following B3's resolver precedent, the annex row assembly reads the per-policy tags from the frontmatter typst already parses, and the *global* lookups (control title, praxis-spine membership) come from a `control_annex.Provider` — a new leaf module (`std` only) that both `typst` and `controls` import. `ControlJoin.annexProvider()` returns the value; its opaque `ctx` points at the read-only join, shared across the concurrent compile tasks.

**TSC 2017 titles**: `ControlJoin` now also loads `data/tsc2017.json` (degrades to id-only when absent), used solely to title tagged criteria in the annex.

## Verification

- `zig build test` — all pass (83 unit incl. extended coverage + audit + new exclusion-validation/annex-provider tests; 9 golden). Non-annex baselines byte-identical.
- `zig build update-golden` — churn limited to the two intended baselines: `report_scf.typ` (out-of-scope summary + GOV-03 marker) and `test_policy_controls.typ` (the annex; the fixture gained TSC tags + a `scope_exclusions` entry).
- `zig build e2e` — starter builds (catalogs absent → graceful degrade).
- Full demo build (`--audit-bundle`) — the exclusion policy's PDF shows the annex; `audit/coverage.json` records `excluded_by: ["Physical Security Policy"]` for PES-01/PES-04 with the schema string still `…/v1`.
- `zola build` + `zola check` — clean; the "Declared Out of Scope" card renders on the policy page and the SCF report shows the out-of-scope third state.

## Stack

Stacked on **#169** (B3) → #168 (B2) → #167 (B1). Base is `feat/control-footnotes-pdf` and retargets to `main` as the stack merges.

Closes #165
Refs #127
