### PR TITLE
feat: audit bundle praxis-join facet (join.json)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,29 @@ versioning; breaking changes to it bump the major version.
 
 ### Added
 
+- **Audit bundle praxis-join facet (`audit/join.json`).** When a praxis control
+  join is configured (`[extra.policypress] praxis_join`), the audit bundle gains
+  a new `join.json` file (schema `policypress/audit-join/v1`) exposing the
+  policy↔praxis cross-check directly, so an external GRC system or auditor can
+  consume it without recomputing it from `coverage.json`. It carries the praxis
+  provenance, a spine summary that partitions every spine control into covered,
+  excluded, or unaddressed (a control both covered and excluded counts as
+  covered, so the three sum to the total), and one row per control in the union
+  of the praxis spine, the SCF-tagged controls, and the declared-out-of-scope
+  controls — each recording spine membership, the policies that declare it, the
+  policies that declare it out of scope, and whether those conflict. The file is
+  written **only** when a join is configured; without one the bundle is
+  byte-for-byte unchanged. The generator (`nix run .#gen-praxis-join`) gained
+  `-o -` to write to stdout, enabling a consumer-side CI drift check (see the
+  Compliance Frameworks guide).
+- The audit bundle's `coverage.json` / `coverage.csv` now carry an additive
+  per-control `excluded_by` list — the policies that declare a control out of
+  scope via `extra.scope_exclusions`. The `policypress/audit-coverage/v1` schema
+  string is unchanged (consumers that exact-match it and ignore unknown keys are
+  unaffected); an exclusion is a distinct third state, never counted as coverage.
+- Scaffolds from `policypress new` now include commented `taxonomies:`/`SCF:`
+  and `extra.scope_exclusions` stubs so authors discover both — still commented,
+  so a fresh scaffold validates unchanged.
 - **Praxis control-join plumbing.** A new optional `config.toml` key,
   `[extra.policypress] praxis_join`, points at a committed JSON file
   (`data/praxis-join.json`, schema `policypress/praxis-join/v1`) listing the bare

--- a/content/guides/compliance-frameworks.md
+++ b/content/guides/compliance-frameworks.md
@@ -219,6 +219,42 @@ optional dotted sub-id (`IAC-01`, `HRS-05.1`, `IAC-21.5`). A malformed id — or
 any `control(…)` shortcode that is not well-formed — is a hard build error, so a
 broken reference can never silently ship in a PDF.
 
+## Checking the praxis join is fresh
+
+The praxis spine lives in a committed file (`data/praxis-join.json`) that a
+consumer regenerates from their praxis flake with `nix run .#gen-praxis-join`.
+praxis is **not** a PolicyPress flake input — PolicyPress is public and a
+praxis-like GRC system is private, and the feature must work for any consumer —
+so there is **no build-time freshness gate**. If the set of controls praxis
+governs changes upstream, the committed file goes stale silently until someone
+regenerates it. Catch that drift in CI by regenerating and diffing:
+
+```bash
+# Pin the provenance fields (generated_at, source.rev) to the committed file so
+# the diff surfaces only real drift in the governed control set, not the date:
+gen=$(jq -r .generated_at data/praxis-join.json)
+rev=$(jq -r .source.rev data/praxis-join.json)
+
+nix run github:sc2in/PolicyPress#gen-praxis-join -- \
+    github:your-org/praxis --generated-at "$gen" --rev "$rev" -o - \
+  | diff - data/praxis-join.json && echo "praxis join is up to date"
+```
+
+`-o -` writes the regenerated document to stdout instead of overwriting the
+file, so `diff` compares the freshly-evaluated spine against the committed one.
+A non-empty diff (non-zero exit) fails the CI step; to fix it, regenerate the
+file for real and commit it:
+
+```bash
+nix run github:sc2in/PolicyPress#gen-praxis-join -- github:your-org/praxis
+git add data/praxis-join.json && git commit -m "chore: refresh praxis join"
+```
+
+The join also surfaces in the [audit bundle](@/reports/assurance.md) as
+`join.json` — the policy↔praxis cross-check (which spine controls have a
+published policy, which are declared out of scope, and where the two conflict),
+written whenever `praxis_join` is configured.
+
 ## The SCF example
 
 The SCF files in `templates/opencontrols/standards/` show a real-world example of this pattern at scale (~1,200 controls). The SCF is published by the [Secure Controls Framework Council](https://securecontrolsframework.com/) under CC BY-ND 4.0. The files ship with descriptions removed - only control IDs, names, and domains are included.

--- a/content/reports/assurance.md
+++ b/content/reports/assurance.md
@@ -28,7 +28,15 @@ PolicyPress site:
   flattened and queryable in one place.
 - [`coverage.json`](/audit/coverage.json) / [`coverage.csv`](/audit/coverage.csv)
   — structured SCF and SOC 2 (TSC 2017) control coverage, the same numbers the
-  [reports](@/reports/_index.md) render.
+  [reports](@/reports/_index.md) render. Each control also carries an
+  `excluded_by` list: the policies that declare it out of scope.
+- [`join.json`](/audit/join.json) — the policy↔praxis join as a first-class
+  facet (written only when a [praxis control join](@/guides/configuration.md#praxis-control-join)
+  is configured). For every control in the union of the praxis spine, the
+  SCF-tagged controls, and the declared-out-of-scope controls, it records
+  whether the control is in the praxis spine, which policies declare it, which
+  declare it out of scope, and whether those two conflict — plus a spine summary
+  (`spine_total` = `spine_covered` + `spine_excluded` + `spine_unaddressed`).
 
 To verify a PDF you downloaded from this site against the manifest:
 

--- a/src/audit.zig
+++ b/src/audit.zig
@@ -31,6 +31,11 @@ const log = std.log.scoped(.audit);
 const schema_manifest = "policypress/audit-manifest/v1";
 const schema_revisions = "policypress/audit-revisions/v1";
 const schema_coverage = "policypress/audit-coverage/v1";
+// The praxis join facet is a NEW file (join.json), so praxis's v1 coverage
+// readers are untouched. It is written only when `config.praxis_join` is set.
+const schema_join = "policypress/audit-join/v1";
+
+const praxis_join = @import("praxis_join");
 
 /// Write the three-file bundle into `audit_dir` (created if needed).
 /// `pp_version` is the PolicyPress version stamped into the manifest.
@@ -181,6 +186,11 @@ pub fn writeBundle(
     }
 
     // ── coverage.json + coverage.csv ─────────────────────────────────────────
+    // The SCF coverage is captured for reuse by the praxis join facet below;
+    // its rows (declared_by / excluded_by, in catalog order) are exactly the
+    // per-control data join.json needs. Backed by the catalog arena, itself
+    // backed by `a`, so it stays valid until writeBundle returns.
+    var scf_cov: ?reports.Coverage = null;
     {
         var frameworks = std.json.Array.init(a);
         var csv: std.Io.Writer.Allocating = .init(a);
@@ -205,6 +215,7 @@ pub fn writeBundle(
                 // when writeBundle returns.
                 var catalog = try reports.init(io, a, catalog_path);
                 const cov = try catalog.coverage(io, kind.taxonomyKey().?, config.policy_dir);
+                if (kind == .scf) scf_cov = cov;
 
                 var controls = std.json.Array.init(a);
                 for (cov.controls) |c| {
@@ -261,7 +272,140 @@ pub fn writeBundle(
         try writeFile(io, a, audit_dir, "coverage.csv", csv_bytes);
     }
 
+    // ── audit/join.json (praxis join facet) ──────────────────────────────────
+    // Written ONLY when a praxis join is configured; when it is absent the
+    // bundle is exactly as before this facet existed.
+    try writeJoinFacet(io, a, config, audit_dir, generated, scf_cov);
+
     log.info("audit bundle written to '{s}' ({d} policies).", .{ audit_dir, manifest_policies.items.len });
+}
+
+/// Write `audit/join.json` (schema `policypress/audit-join/v1`) — the
+/// policy↔praxis cross-check as a first-class facet, so praxis and auditors can
+/// consume it directly instead of recomputing it from coverage.json. A NEW
+/// file: praxis's coverage/v1 readers are untouched.
+///
+/// Returns immediately (writing nothing) when `config.praxis_join` is unset, so
+/// the rest of the bundle is unchanged for sites without a join.
+///
+/// `controls` rows are the union of (praxis spine ids) ∪ (SCF-tagged ids) ∪
+/// (excluded ids): every catalog control with coverage/exclusion data or spine
+/// membership, in catalog order, followed by any spine id the local catalog
+/// does not know (SCF version skew) in the join's sorted id order — fully
+/// deterministic. `scf_cov` supplies the per-control declared_by / excluded_by.
+fn writeJoinFacet(
+    io: std.Io,
+    a: Allocator,
+    config: Config,
+    audit_dir: []const u8,
+    generated: []const u8,
+    scf_cov: ?reports.Coverage,
+) !void {
+    const rel = config.praxis_join orelse return;
+
+    // Resolve relative to the site root, matching how main.zig feeds the join
+    // path to ControlJoin. A configured-but-unloadable join is a hard error —
+    // silently dropping coverage data is worse than failing the build.
+    const path = try std.fs.path.join(a, &.{ config.root, rel });
+    var join = try praxis_join.PraxisJoin.load(io, a, path);
+    defer join.deinit();
+
+    var controls = std.json.Array.init(a);
+
+    // Spine partition counts. Tie-break: a control that is BOTH covered and
+    // excluded counts as covered (coverage precedes an exclusion), so the three
+    // buckets stay disjoint and sum to the spine total.
+    var spine_covered: usize = 0;
+    var spine_excluded: usize = 0;
+    var spine_unaddressed: usize = 0;
+
+    // Spine ids already emitted as a catalog row, so the skew loop below never
+    // double-counts one.
+    var seen_spine: std.StringHashMapUnmanaged(void) = .empty;
+
+    if (scf_cov) |cov| {
+        for (cov.controls) |c| {
+            const in_spine = join.contains(c.control_id);
+            const covered = c.policies.len > 0;
+            const excluded = c.excluded_by.len > 0;
+            // Union filter: skip controls with no coverage, no exclusion, and no
+            // spine membership — they are noise for a join view.
+            if (!(in_spine or covered or excluded)) continue;
+
+            var obj: std.json.ObjectMap = .empty;
+            try obj.put(a, "id", .{ .string = c.control_id });
+            try obj.put(a, "in_praxis_spine", .{ .bool = in_spine });
+            var decl = std.json.Array.init(a);
+            for (c.policies) |p| try decl.append(.{ .string = p });
+            try obj.put(a, "declared_by", .{ .array = decl });
+            var excl = std.json.Array.init(a);
+            for (c.excluded_by) |p| try excl.append(.{ .string = p });
+            try obj.put(a, "excluded_by", .{ .array = excl });
+            // Cross-policy tension B4 flags as advisory: some policy claims the
+            // control while another disclaims it (same-policy is a critical
+            // validation error, so a conflict here is always cross-policy).
+            try obj.put(a, "conflict", .{ .bool = covered and excluded });
+            try controls.append(.{ .object = obj });
+
+            if (in_spine) {
+                try seen_spine.put(a, c.control_id, {});
+                if (covered) {
+                    spine_covered += 1;
+                } else if (excluded) {
+                    spine_excluded += 1;
+                } else {
+                    spine_unaddressed += 1;
+                }
+            }
+        }
+    }
+
+    // Spine ids the local catalog does not carry: no coverage data exists, so
+    // they are unaddressed. Appended after the catalog-ordered rows in the
+    // join's (sorted) id order; deduped so a repeated join id counts once.
+    for (join.ids) |id| {
+        if (seen_spine.contains(id)) continue;
+        try seen_spine.put(a, try a.dupe(u8, id), {});
+        spine_unaddressed += 1;
+
+        var obj: std.json.ObjectMap = .empty;
+        try obj.put(a, "id", .{ .string = try a.dupe(u8, id) });
+        try obj.put(a, "in_praxis_spine", .{ .bool = true });
+        try obj.put(a, "declared_by", .{ .array = std.json.Array.init(a) });
+        try obj.put(a, "excluded_by", .{ .array = std.json.Array.init(a) });
+        try obj.put(a, "conflict", .{ .bool = false });
+        try controls.append(.{ .object = obj });
+    }
+
+    // spine_total is the number of distinct spine ids; the loops above place
+    // each in exactly one bucket, so the identity
+    //   spine_covered + spine_excluded + spine_unaddressed == spine_total
+    // holds by construction.
+    const spine_total = join.id_set.count();
+
+    var praxis_obj: std.json.ObjectMap = .empty;
+    try praxis_obj.put(a, "generated_at", .{ .string = try a.dupe(u8, join.generated_at) });
+    try praxis_obj.put(a, "source_rev", .{ .string = try a.dupe(u8, join.source_rev) });
+    try praxis_obj.put(a, "scf_version", .{ .string = try a.dupe(u8, join.scf_version) });
+
+    var summary: std.json.ObjectMap = .empty;
+    try summary.put(a, "spine_total", .{ .integer = @intCast(spine_total) });
+    try summary.put(a, "spine_covered", .{ .integer = @intCast(spine_covered) });
+    try summary.put(a, "spine_excluded", .{ .integer = @intCast(spine_excluded) });
+    try summary.put(a, "spine_unaddressed", .{ .integer = @intCast(spine_unaddressed) });
+
+    var root: std.json.ObjectMap = .empty;
+    try root.put(a, "schema", .{ .string = schema_join });
+    try root.put(a, "generated_at", .{ .string = generated });
+    try root.put(a, "praxis", .{ .object = praxis_obj });
+    try root.put(a, "summary", .{ .object = summary });
+    try root.put(a, "controls", .{ .array = controls });
+    try writeJson(io, a, audit_dir, "join.json", .{ .object = root });
+
+    log.info(
+        "audit bundle: join.json written ({d} spine controls: {d} covered, {d} excluded, {d} unaddressed).",
+        .{ spine_total, spine_covered, spine_excluded, spine_unaddressed },
+    );
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────

--- a/src/main.zig
+++ b/src/main.zig
@@ -1067,8 +1067,21 @@ fn runNew(io: std.Io, alloc: Allocator, args: []const [:0]const u8) !void {
         \\date: {s}
         \\description: ""
         \\draft: true
+        \\# Map this policy to compliance-framework controls by listing control ids
+        \\# (see the "Compliance Frameworks" guide). Ids must exist in your control
+        \\# catalog (e.g. data/scf.json) or a --strict build fails. Uncomment to use:
+        \\# taxonomies:
+        \\#   SCF:
+        \\#     - IAC-01
+        \\#     - IAC-02
         \\extra:
         \\  last_reviewed: {s}
+        \\  # Declare controls explicitly out of scope ("we do not do X"). Each entry
+        \\  # needs an `id` and a non-empty `reason`; excluded controls are a distinct
+        \\  # state (neither covered nor a silent gap). Uncomment to use:
+        \\  # scope_exclusions:
+        \\  #   - id: PES-01
+        \\  #     reason: "We operate no physical facilities."
         \\  major_revisions:
         \\    - version: "0.1"
         \\      date: {s}

--- a/src/test.zig
+++ b/src/test.zig
@@ -48,6 +48,16 @@ fn tmpAbsPath(alloc: Allocator, tmp: *tst.TmpDir) ![]u8 {
     return std.fs.path.join(alloc, &.{ buf[0..cwd_len], ".zig-cache", "tmp", &tmp.sub_path });
 }
 
+/// Write `bytes` to `dir/name`, truncating any existing file. Small helper for
+/// staging scratch fixtures (policies, fake PDFs) in the audit-bundle tests.
+fn writeFileAt(alloc: Allocator, dir: []const u8, name: []const u8, bytes: []const u8) !void {
+    const p = try std.fs.path.join(alloc, &.{ dir, name });
+    defer alloc.free(p);
+    const f = try std.Io.Dir.cwd().createFile(io, p, .{ .truncate = true });
+    defer f.close(io);
+    try f.writeStreamingAll(io, bytes);
+}
+
 test {
     _ = utils;
     _ = zigmark;
@@ -1408,6 +1418,149 @@ test "audit bundle: manifest hashes, newest revision, coverage export" {
         try tst.expect(saw_pes01);
         try tst.expect(saw_hrs05);
     }
+
+    // ── join.json gating: NOT written without a praxis_join ─────────────────
+    // TestConfig configures no praxis_join, so the join facet must be absent —
+    // the bundle is exactly as it was before the facet existed.
+    {
+        const p = try std.fs.path.join(alloc, &.{ audit_dir, "join.json" });
+        defer alloc.free(p);
+        const exists = if (std.Io.Dir.cwd().access(io, p, .{})) |_| true else |_| false;
+        try tst.expect(!exists);
+    }
+}
+
+test "audit bundle: praxis join facet (join.json)" {
+    const alloc = tst.allocator;
+    var conf = try config.load(io, alloc, TestConfig);
+    defer conf.deinit(alloc);
+    conf.date = .{ .year = 2026, .month = 1, .day = 1 };
+    // Enable the facet. The path is resolved relative to conf.root (the repo
+    // root under test), matching main.zig's join-path resolution.
+    conf.praxis_join = "data/praxis-join.json";
+
+    var tmp = tst.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try tmpAbsPath(alloc, &tmp);
+    defer alloc.free(base);
+
+    const pol_dir = try std.fs.path.join(alloc, &.{ base, "policies" });
+    defer alloc.free(pol_dir);
+    try std.Io.Dir.cwd().createDirPath(io, pol_dir);
+    const pdf_dir = try std.fs.path.join(alloc, &.{ base, "pdfs" });
+    defer alloc.free(pdf_dir);
+    try std.Io.Dir.cwd().createDirPath(io, pdf_dir);
+
+    // Policy 1: the shared fixture — covers HRS-05.* (all in the spine) and
+    // declares PES-01 (also in the spine) out of scope.
+    const src_md = try std.Io.Dir.cwd().readFileAlloc(io, "src/test/test_policy.md", alloc, .limited(1 << 20));
+    defer alloc.free(src_md);
+    try writeFileAt(alloc, pol_dir, "test_policy.md", src_md);
+    try writeFileAt(alloc, pdf_dir, "Test_Policy_-_v1.1.pdf", "fake pdf bytes");
+
+    // Policy 2: COVERS PES-01, which policy 1 excludes — a cross-policy conflict
+    // (declared_by AND excluded_by both non-empty) and, via the tie-break, a
+    // spine control that counts as covered despite the exclusion.
+    const conflict_md =
+        \\---
+        \\title: "Conflict Test Policy"
+        \\date: 2024-11-13
+        \\taxonomies:
+        \\  SCF:
+        \\    - PES-01
+        \\extra:
+        \\  owner: SC2
+        \\  last_reviewed: 2025-02-24
+        \\  major_revisions:
+        \\    - version: "1.0"
+        \\      date: 2024-11-13
+        \\      approved_by: Ada Byrne
+        \\      description: Initial version.
+        \\---
+        \\
+        \\## Body
+        \\
+        \\Content.
+        \\
+    ;
+    try writeFileAt(alloc, pol_dir, "conflict_test.md", conflict_md);
+    try writeFileAt(alloc, pdf_dir, "Conflict_Test_Policy_-_v1.0.pdf", "fake pdf bytes");
+
+    alloc.free(conf.policy_dir);
+    conf.policy_dir = try alloc.dupe(u8, pol_dir);
+    conf.build_dir = pdf_dir;
+
+    const audit_dir = try std.fs.path.join(alloc, &.{ base, "audit" });
+    defer alloc.free(audit_dir);
+    try audit.writeBundle(io, alloc, conf, audit_dir, "9.9.9-test");
+
+    const p = try std.fs.path.join(alloc, &.{ audit_dir, "join.json" });
+    defer alloc.free(p);
+    const bytes = try std.Io.Dir.cwd().readFileAlloc(io, p, alloc, .limited(16 << 20));
+    defer alloc.free(bytes);
+    const parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
+    defer parsed.deinit();
+    const root = parsed.value.object;
+
+    // Schema + provenance carried from the loaded join.
+    try tst.expectEqualStrings("policypress/audit-join/v1", root.get("schema").?.string);
+    try tst.expectEqualStrings("2026-01-01", root.get("generated_at").?.string);
+    const prov = root.get("praxis").?.object;
+    try tst.expectEqualStrings("2026-07-22", prov.get("generated_at").?.string);
+    try tst.expectEqualStrings("demo-fixture", prov.get("source_rev").?.string);
+    try tst.expectEqualStrings("2026.1.1", prov.get("scf_version").?.string);
+
+    // Summary math identity: covered + excluded + unaddressed == total.
+    const sm = root.get("summary").?.object;
+    const total = sm.get("spine_total").?.integer;
+    const covered = sm.get("spine_covered").?.integer;
+    const excluded = sm.get("spine_excluded").?.integer;
+    const unaddressed = sm.get("spine_unaddressed").?.integer;
+    try tst.expectEqual(@as(i64, 23), total); // the demo fixture has 23 spine ids
+    try tst.expectEqual(total, covered + excluded + unaddressed);
+    // HRS-05.* (6) plus PES-01 (covered by the conflict policy, tie-break) = 7.
+    try tst.expectEqual(@as(i64, 7), covered);
+    // PES-01 is covered, so it does NOT count toward excluded.
+    try tst.expectEqual(@as(i64, 0), excluded);
+
+    // Walk the control rows for the three representative states.
+    var saw_pes01 = false;
+    var saw_hrs05 = false;
+    var saw_mon02 = false;
+    for (root.get("controls").?.array.items) |cv| {
+        const c = cv.object;
+        const cid = c.get("id").?.string;
+        const in_spine = c.get("in_praxis_spine").?.bool;
+        const decl = c.get("declared_by").?.array.items;
+        const excl = c.get("excluded_by").?.array.items;
+        const conflict = c.get("conflict").?.bool;
+        if (std.mem.eql(u8, cid, "PES-01")) {
+            saw_pes01 = true;
+            try tst.expect(in_spine); // in-spine AND excluded
+            try tst.expectEqual(@as(usize, 1), decl.len);
+            try tst.expectEqualStrings("Conflict Test Policy", decl[0].string);
+            try tst.expectEqual(@as(usize, 1), excl.len);
+            try tst.expectEqualStrings("Test Policy", excl[0].string);
+            try tst.expect(conflict); // the cross-policy tension
+        } else if (std.mem.eql(u8, cid, "HRS-05")) {
+            saw_hrs05 = true;
+            try tst.expect(in_spine);
+            try tst.expectEqual(@as(usize, 1), decl.len);
+            try tst.expectEqualStrings("Test Policy", decl[0].string);
+            try tst.expectEqual(@as(usize, 0), excl.len);
+            try tst.expect(!conflict);
+        } else if (std.mem.eql(u8, cid, "MON-02")) {
+            // A gap id: in the spine but neither covered nor excluded.
+            saw_mon02 = true;
+            try tst.expect(in_spine);
+            try tst.expectEqual(@as(usize, 0), decl.len);
+            try tst.expectEqual(@as(usize, 0), excl.len);
+            try tst.expect(!conflict);
+        }
+    }
+    try tst.expect(saw_pes01);
+    try tst.expect(saw_hrs05);
+    try tst.expect(saw_mon02);
 }
 
 // ── praxis join loader (src/praxis_join.zig) ─────────────────────────────────

--- a/tools/gen-praxis-join.py
+++ b/tools/gen-praxis-join.py
@@ -31,7 +31,8 @@ Options:
                              Families the spine was built from; repeatable and/or
                              comma-separated (default: GOV).
   --generated-at YYYY-MM-DD  Override the generation date (default: today, UTC).
-  -o, --output FILE          Output path (default: <repo>/data/praxis-join.json).
+  -o, --output FILE          Output path (default: <repo>/data/praxis-join.json);
+                             "-" writes to stdout (for a `| diff -` drift check).
 
 Stdlib only. Deterministic output: ids and families are sorted and deduped, keys
 are emitted in a stable order, and there are no incidental timestamps beyond
@@ -92,7 +93,7 @@ def main() -> int:
         help="families the spine was built from (repeatable/comma-separated)",
     )
     parser.add_argument("--generated-at", metavar="YYYY-MM-DD", help="override the generation date")
-    parser.add_argument("-o", "--output", metavar="FILE", help="output path")
+    parser.add_argument("-o", "--output", metavar="FILE", help='output path ("-" for stdout)')
     args = parser.parse_args()
 
     if args.ids_json is None and args.flake is None:
@@ -110,13 +111,22 @@ def main() -> int:
         "ids": sorted(set(ids)),
     }
 
-    out_path = (
-        Path(args.output)
-        if args.output
-        else Path(__file__).resolve().parent.parent / "data" / "praxis-join.json"
-    )
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    rendered = json.dumps(doc, indent=2, ensure_ascii=False) + "\n"
+
+    # `-o -` writes the document to stdout instead of a file, so a consumer can
+    # pipe it straight into a drift check (`... -o - | diff - data/praxis-join.json`);
+    # the human-readable summary always goes to stderr, keeping stdout clean.
+    if args.output == "-":
+        sys.stdout.write(rendered)
+        out_path = "(stdout)"
+    else:
+        out_path = (
+            Path(args.output)
+            if args.output
+            else Path(__file__).resolve().parent.parent / "data" / "praxis-join.json"
+        )
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(rendered, encoding="utf-8")
 
     print(
         f"wrote {out_path} — {len(doc['ids'])} ids, families {doc['organizational_families']} "


### PR DESCRIPTION
Exposes the policy↔praxis join as a first-class audit-bundle facet (`audit/join.json`) so praxis (sc2in/Praxis#27) and auditors can consume it directly instead of recomputing it from `coverage.json`.

Closes #166. Part of #127.

## Stacked PR

This is B5 of the #127 stack, stacked on:

`#170 (B4) → #169 (B3) → #168 (B2) → #167 (B1)`

Based on B4's head (`feat/scope-exclusions`) and opened against it; the base retargets to `main` as the stack merges. Review after the parents.

## What's here

- **`src/audit.zig`** — `writeBundle()` writes `audit/join.json` (new schema `policypress/audit-join/v1`, a NEW file so praxis's `audit-coverage/v1` readers are untouched) **only when `config.praxis_join` is set**. When it is unset the bundle is byte-for-byte unchanged. It reuses the SCF coverage already computed for `coverage.json` and adds:
  - `praxis` — provenance copied from the loaded join (`generated_at`, `source_rev`, `scf_version`).
  - `summary` — `spine_total` / `spine_covered` / `spine_excluded` / `spine_unaddressed`, with the invariant `covered + excluded + unaddressed == total`. Tie-break (documented in a comment): a control that is **both** covered and excluded counts as **covered**, so the three buckets stay disjoint.
  - `controls` — one row per control in the union of (praxis spine) ∪ (SCF-tagged) ∪ (excluded), in catalog order, with any spine id absent from the local catalog appended in the join's sorted id order (fully deterministic). Each row carries `in_praxis_spine`, `declared_by`, `excluded_by`, and `conflict` (declared_by AND excluded_by both non-empty — the cross-policy tension B4 flags as advisory).
  - Atomic temp+rename write, same idiom as the other facets.
- **`tools/gen-praxis-join.py`** — adds `-o -` (write to stdout) so the consumer CI drift recipe can pipe the regenerated spine straight into `diff`.
- **`src/main.zig`** — `policypress new` scaffolds now carry commented `taxonomies:`/`SCF:` and `extra.scope_exclusions` stubs so authors discover both; kept commented so a fresh scaffold still validates unchanged.
- **Docs** — `content/reports/assurance.md` gains a `join.json` bullet; `content/guides/compliance-frameworks.md` gains a "Checking the praxis join is fresh" recipe (no build-time freshness gate is possible because praxis is not a flake input).
- **Tests** — a new audit-bundle test asserts the `join.json` schema, praxis provenance, the summary math identity, a cross-policy `conflict` row, and representative covered / excluded-in-spine / gap rows; the existing audit test now asserts `join.json` is **absent** when `praxis_join` is unset.
- **CHANGELOG** — the new `join.json` facet, the additive `excluded_by` in `coverage.json`/`coverage.csv` (schema string unchanged — not previously noted by B4), and the scaffold stubs.

## Verification

- `zig build test` → 93/93 tests pass.
- `zig build e2e` → success.
- `zola build` → 28 pages, clean (validates the doc changes).
- Full demo build (`--audit-bundle`, join configured): `join.json` summary `{spine_total: 23, spine_covered: 20, spine_excluded: 1, spine_unaddressed: 2}` (identity holds), `PES-01` → `in_praxis_spine: true`, `excluded_by: ["Physical Security Policy"]`, `MON-02` → in-spine gap row.
- Gating: rebuilt with `praxis_join` unset — `audit/` contains only `manifest.json`, `revisions.json`, `coverage.json`, `coverage.csv` (no `join.json`), and `coverage.json` is unchanged.
