### PR TITLE
chore: #151 math/PDF review follow-ups (opt-in test, mitex version, drop zigmark stopgaps) (#152)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,25 @@
               in
               if match != null then builtins.head match else "0.0.0";
 
+            # mitex version, parsed from the `#import "@preview/mitex:X"` line in
+            # src/typst.zig — the single source of truth for the version the PDF
+            # math path imports. `typstWithMath` below asserts the nixpkgs-vendored
+            # package matches this, so a nixpkgs mitex bump fails loudly here at
+            # eval time (with an actionable message) instead of as a non-obvious
+            # typst "package not found" error deep in the pdf-accessibility build.
+            mitexImportVersion =
+              let
+                src = builtins.readFile ./src/typst.zig;
+                # The import lives in a Zig string literal, so its closing quote
+                # is backslash-escaped in the source (`mitex:0.2.7\"`). Capture
+                # just the version digits; `[0-9.]+` stops at the backslash.
+                match = builtins.match ".*@preview/mitex:([0-9.]+).*" src;
+              in
+              if match != null then
+                builtins.head match
+              else
+                throw "flake.nix: could not find the `@preview/mitex:X` import version in src/typst.zig";
+
             # Pin Zig 0.16.0 from zig2nix rather than nixpkgs' `pkgs.zig`, which
             # tracks an older release than this project's minimum_zig_version.
             zig = zig2nix.outputs.packages.${system}."zig-0_16_0";
@@ -174,12 +193,26 @@
               ];
             };
 
+            # typst with the mitex package vendored into its offline package
+            # cache, so `@preview/mitex` resolves in the hermetic build (opt-in
+            # policy math renders TeX via mitex). typst's `@preview/mitex:X` import
+            # is version-exact, so the vendored package MUST match the version in
+            # src/typst.zig. Assert that here — reading the version off the same
+            # `p.mitex` that gets vendored — so a nixpkgs bump that drifts the two
+            # apart is a loud, actionable eval-time failure, not a cryptic compile.
+            typstWithMath = pkgs.typst.withPackages (
+              p:
+              if p.mitex.version == mitexImportVersion then
+                [ p.mitex ]
+              else
+                throw ''
+                  mitex version mismatch: nixpkgs provides mitex ${p.mitex.version}, but src/typst.zig imports `@preview/mitex:${mitexImportVersion}`.
+                  Update the `#import "@preview/mitex:X"` line in src/typst.zig to ${p.mitex.version} (and regenerate the math golden with `zig build update-golden`), or pin nixpkgs to a mitex ${mitexImportVersion} release.
+                ''
+            );
+
             runtimeDeps = with pkgs; [
-              # typst with the mitex package vendored into its offline package
-              # cache, so `@preview/mitex` resolves in the hermetic build (opt-in
-              # policy math renders TeX via mitex). Keep the mitex version here in
-              # lock-step with the `#import "@preview/mitex:X"` line in src/typst.zig.
-              (typst.withPackages (p: [ p.mitex ]))
+              typstWithMath
               zola
             ];
 

--- a/src/test.zig
+++ b/src/test.zig
@@ -272,10 +272,20 @@ test "typst source: math stays off without extra.math opt-in" {
     var conf = try config.load(io, alloc, TestConfig);
     defer conf.deinit(alloc);
 
-    // test_policy_render.md does not set extra.math, so no mitex import appears
-    // even though math would be inert; guards the opt-in gate against drift.
-    var rendered = try typst.render(io, alloc, conf, "src/test/test_policy_render.md");
+    // test_policy_math_off.md CONTAINS `$…$` / `$$…$$` math syntax but does NOT
+    // set extra.math. With the gate off, zigmark parses `$` as ordinary text and
+    // escapes it to `\$`; nothing becomes a mitex equation. This guards the
+    // opt-in gate against a regression to always-on (a fixture with no math
+    // could not catch that — there'd be nothing to mis-parse).
+    var rendered = try typst.render(io, alloc, conf, "src/test/test_policy_math_off.md");
     defer rendered.deinit(alloc);
+
+    // The `$` in `$x^2$` stays escaped as literal text — not opened as math.
+    try tst.expect(std.mem.indexOf(u8, rendered.source, "\\$x^2\\$") != null);
+    // No equation was emitted: neither the inline `#mi(` nor the display
+    // `#mitex(` renderer calls, and thus no mitex import either.
+    try tst.expect(std.mem.indexOf(u8, rendered.source, "#mi(") == null);
+    try tst.expect(std.mem.indexOf(u8, rendered.source, "#mitex(") == null);
     try tst.expect(std.mem.indexOf(u8, rendered.source, "@preview/mitex") == null);
 }
 

--- a/src/test/test_policy_math_off.md
+++ b/src/test/test_policy_math_off.md
@@ -1,0 +1,32 @@
+---
+title: "Math Off Policy"
+description: "Fixture with TeX math syntax but no extra.math opt-in; math must stay inert"
+date: 2024-11-13
+weight: 10
+taxonomies:
+  TSC2017:
+    - CC2.1
+  SCF:
+    - HRS-05
+extra:
+  owner: SC2
+  last_reviewed: 2025-02-24
+  major_revisions:
+    - date: 2025-06-24
+      description: Initial version.
+      revised_by: Ada Byrne
+      approved_by: Ada Byrne
+      version: "1.0"
+---
+
+## Purpose
+
+This policy deliberately contains TeX math syntax but never sets extra.math, so
+the opt-in gate must leave it inert.
+
+## Formula
+
+The residual risk threshold is $x^2$ and, with math off, the dollar signs must
+survive as escaped literal text rather than opening a Typst equation.
+
+Display math like $$E = mc^2$$ must likewise stay literal.

--- a/src/typst.zig
+++ b/src/typst.zig
@@ -563,9 +563,13 @@ fn writePreamble(writer: anytype, opts: DocOpts) !void {
     // `#mitex(…, alt: …)` (per-equation alt text, which typst's PDF/UA-1 mode
     // requires) but deliberately does not import mitex, so the consumer's
     // preamble must. Emitted here, not in writeDocSetup, so the report PDFs
-    // (which share writeDocSetup and have no math) stay mitex-free. The mitex
-    // version is pinned in lock-step with flake.nix's `typst.withPackages
-    // [ mitex ]` (offline package cache).
+    // (which share writeDocSetup and have no math) stay mitex-free.
+    //
+    // This `@preview/mitex:X` line is the single source of truth for the version.
+    // flake.nix parses it and asserts the vendored nixpkgs mitex package matches
+    // (typst's import is version-exact), so a nixpkgs bump that drifts the two
+    // apart fails loudly at flake eval. Bumping the version here means updating
+    // the math golden (`zig build update-golden`).
     if (opts.math) {
         try writer.writeAll("#import \"@preview/mitex:0.2.7\": mi, mitex\n\n");
     }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -393,6 +393,9 @@ test "replace_zola_at" {
 /// filesystem access, so a genuinely missing image surfaces as a clear Typst
 /// compile error rather than being silently dropped.
 pub fn rewrite_image_paths(alloc: Allocator, txt: *Array(u8)) !void {
+    // The lazy `.*?\)` stops at the first `)`, so a destination or title that
+    // itself contains `)` (e.g. `![a](/x(1).png)`) is truncated. Pathological
+    // for policy images; documented in #152 as a negligible edge — no action.
     const img: mvzr.Regex = mvzr.compile("!\\[.*?\\]\\(/.*?\\)").?;
     if (!img.isMatch(txt.items)) return;
 


### PR DESCRIPTION
Follow-ups from the #151 code review (issue #152). Kept edits localized to the math path (`src/typst.zig`, `src/test.zig`, a new fixture, and the flake's mitex packaging).

## Item 1 — strengthen the math-off negative test (test-coverage)
The old test rendered `test_policy_render.md`, which has **no** `$…$` at all, so a regression to always-on math (`parser.math = true` unconditionally) would still pass — nothing to mis-parse.

- Added `src/test/test_policy_math_off.md`: valid policy frontmatter, body contains `$x^2$` and `$$E = mc^2$$`, but does **not** set `extra.math`.
- Repointed `test "typst source: math stays off without extra.math opt-in"` at it and strengthened the assertions: the inline `$` stays escaped (`\$x^2\$`), and there is **no** `#mi(`, **no** `#mitex(`, and no `@preview/mitex` import. That actually guards the opt-in gate.

## Item 2 — de-duplicate the mitex version (maintainability)
**Choice: a build-time consistency assertion in `flake.nix` (loud, obvious failure), keeping `src/typst.zig` as the single source of truth for the version.**

`src/typst.zig` hardcodes `#import "@preview/mitex:0.2.7"`; `flake.nix` vendors `p.mitex` from nixpkgs. typst's `@preview` imports are **version-exact**, so the two must match or the PDF compile fails obscurely.

Rather than injecting the version into the Zig binary (which must also build/run outside Nix) or pinning a second literal that can still drift, `flake.nix` now:
- parses the `@preview/mitex:X` version out of `src/typst.zig`, and
- asserts it equals `p.mitex.version` — read off the *same* `p.mitex` that gets vendored (inside `typst.withPackages`).

A nixpkgs mitex bump that drifts the two apart is now a **loud, actionable eval-time failure** (with a message telling the maintainer exactly what to change), instead of a cryptic "package not found" deep in the `pdf-accessibility` build. `src/typst.zig` stays the one place the version is written.

## Item 4 — `)`-in-image-path regex edge (negligible)
Added a one-line comment on `rewrite_image_paths` noting the lazy `.*?\)` truncation edge. No behavior change (issue says no action expected). Item 3 (`rewrite_image_paths` pre-parse scope) left as-is per the issue.

## zigmark#78 / #79 stopgap cleanups — already done
These were listed as "once the linked zigmark fixes land". They were in fact **already completed inside the final #151 merge** (which bumped zigmark to v0.10.0 mid-PR):
- **#78** — the document-wide `#set math.equation(alt: "Mathematical formula")` fallback is already gone; `math.equation(alt:` does not appear anywhere in `src/`, and the math golden/test already assert its absence.
- **#79** — the `extra.math` gate already reads bool-only (`v == .bool and v.bool`); no `"true"` string dual-accept remains.

I verified both against the pinned **zigmark v0.11.0** (`63f68d4`, which includes #78/#79) and confirmed no change was needed. **Critically, I confirmed PDF/UA-1 still holds without the fallback:** `nix build .#checks.x86_64-linux.pdf-accessibility` (veraPDF) passes, and the demo `example-security-policy.md` genuinely has `math: true` with `$…$`, so per-equation alt text alone satisfies UA-1.

## Verification
- `zig build test` — **93/93 tests passed** (includes the strengthened negative test).
- `nix build .#checks.x86_64-linux.pdf-accessibility` — **green** (veraPDF PDF/UA-1; also exercises the new flake mitex assertion, confirming nixpkgs mitex == 0.2.7).
- `zig build e2e` — success.
- **No golden drift**: `zig build update-golden` produced no changes under `tests/golden/` (version stayed 0.2.7; fallback already absent). Did not touch `test_policy_controls.typ`.
- `nix fmt` (treefmt) and `zig fmt --check` clean.

Closes #152