### PR TITLE
fix: linked PDF filename follows actual redaction state, not redact_web (#159)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,10 +23,12 @@ inputs:
     default: "false"
   redact_mode:
     description: >
-      Set to 'true' to redact content inside redaction shortcode tags.
-      Set to 'false' (default) to include all content.
+      Redact content inside redaction shortcode tags in the PDFs. 'true' forces
+      redaction on; 'false' forces it off; '' (default) inherits the site's
+      [extra.policypress] redact setting. Inheriting keeps the PDF links (which
+      follow the effective redaction state) in lock-step with config.toml (#159).
     required: false
-    default: "false"
+    default: ""
   generate_draft_pdfs:
     description: >
       Set to 'true' to also generate a second set of PDFs stamped with a DRAFT
@@ -224,8 +226,11 @@ runs:
         # render with JavaScript disabled. Operates on the just-built HTML.
         policypress render-diagrams public
 
-        # Build flags - explicitly set draft/redact so action inputs always
-        # override whatever is in the consumer's config.toml.
+        # Build flags. draft_mode is always set explicitly so the action input
+        # overrides config.toml. redact_mode inherits config when unset ('') so
+        # a config-only consumer can drive PDF redaction from [extra.policypress]
+        # redact and keep the PDF links in lock-step (#159); an explicit
+        # true/false still overrides.
         ARGS=(-c "${PP_CONFIG_PATH}" -o "${PP_OUTPUT_DIR}/pdfs")
         if [ "${PP_DRAFT_MODE}" = "true" ]; then
           ARGS+=(--draft)
@@ -234,7 +239,7 @@ runs:
         fi
         if [ "${PP_REDACT_MODE}" = "true" ]; then
           ARGS+=(--redact)
-        else
+        elif [ "${PP_REDACT_MODE}" = "false" ]; then
           ARGS+=(--no-redact)
         fi
         # Official run only: the draft pass below must never overwrite the
@@ -252,7 +257,7 @@ runs:
           DRAFT_ARGS=(-c "${PP_CONFIG_PATH}" -o "${PP_OUTPUT_DIR}/pdfs" --draft)
           if [ "${PP_REDACT_MODE}" = "true" ]; then
             DRAFT_ARGS+=(--redact)
-          else
+          elif [ "${PP_REDACT_MODE}" = "false" ]; then
             DRAFT_ARGS+=(--no-redact)
           fi
           policypress "${DRAFT_ARGS[@]}"

--- a/config.toml
+++ b/config.toml
@@ -195,9 +195,14 @@ library = "katex" # options: "katex", "mathjax". default is "katex".
 
 # PolicyPress configuration
 [extra.policypress]
-# Set to true to render a black redaction bar over {% redact() %}...{% end %} blocks on the website.
-# Does not affect PDF generation - use --redact flag on the CLI for PDF redaction.
+# Render a black redaction bar over {% redact() %}...{% end %} blocks on the
+# *website*. Web-only (#115); does not itself affect PDF generation.
 redact_web = true
+# Redact the *PDFs* too: mask {% redact() %} spans, add a "(Redacted)" title and
+# the "__Redacted__" filename infix. Kept in step with redact_web so the site's
+# PDF links resolve (#159). --redact/--no-redact (redact_mode in the action)
+# still override this.
+redact = true
 show_draft_pdfs = true
 policy_dir = "policies/"
 policy_root = "policies/_index.md"

--- a/content/guides/configuration.md
+++ b/content/guides/configuration.md
@@ -46,14 +46,17 @@ policy_dir = "policies/"
 
 | Field | Location | Type | Default | Description |
 |---|---|---|---|---|
-| `redact_web` | `[extra.policypress]` | bool | `false` | When `true`, renders a redaction bar over `{%/* redact() */%} … {%/* end */%}` blocks on the website. Does **not** affect PDF generation — use `--redact` on the CLI. |
+| `redact_web` | `[extra.policypress]` | bool | `false` | When `true`, renders a redaction bar over `{%/* redact() */%} … {%/* end */%}` blocks on the **website**. Web-only (#115): it does **not** affect PDFs — use `redact` (below) for those. |
+| `redact` | `[extra.policypress]` | bool | `false` | When `true`, the generated **PDFs** are redacted: `{%/* redact() */%} … {%/* end */%}` spans are masked, the title gains a "(Redacted)" suffix, and the filename gains a `__Redacted__` infix. The policy pages key each PDF download link off this value, so the links always resolve to the files produced (#159). `--redact` / `--no-redact` on the CLI — and the action's `redact_mode` — override it. Independent of `redact_web`. |
 | `show_draft_pdfs` | `[extra.policypress]` | bool | `false` | When `true`, links to draft PDFs appear on the policy index page |
 | `report_pdfs` | `[extra.policypress]` | bool | `true` | Generate downloadable PDFs for the compliance reports (SCF/SOC 2 coverage, policy review) alongside the policy PDFs. Coverage reports are skipped with a note when the matching `data/` control catalog is absent. Report PDFs are produced by official (non-draft) builds only — if your site *only* ever builds with `draft_mode`, set this to `false` so the report pages don't show download buttons for files that are never generated. |
 | `audit_bundle` | `[extra.policypress]` | bool | `false` | Write a machine-readable audit bundle next to the PDFs (`audit/manifest.json` with per-PDF sha-256 hashes, `revisions.json`, `coverage.json`/`.csv`) so auditors and evidence collectors can consume the compliance state without scraping the site. Also available as the `--audit-bundle` CLI flag and the action's `audit_bundle` input. |
 | `praxis_join` | `[extra.policypress]` | string | - | Path to the praxis control-join file (see [Praxis control join](#praxis-control-join)). Unset by default; when unset, every praxis coverage surface degrades gracefully. |
 
 > [!NOTE]
-> Draft and redact modes can also be set at build time via GitHub Action inputs or CLI flags (`--draft` / `--redact`). Action inputs always override `config.toml`.
+> `redact_web` masks the website and `redact` masks the PDFs — two independent knobs (#115), but the policy pages link each PDF by a name that encodes the PDF's redaction state, so **keep the two in step unless you deliberately want a masked site with full PDFs** (or vice versa). A mismatch is reported as an advisory at build time; the links still resolve because they follow `redact`.
+>
+> Draft and redact can also be set at build time via GitHub Action inputs or CLI flags (`--draft` / `--redact` / `--no-redact`). An explicit CLI flag or `draft_mode` input always overrides `config.toml`; the action's `redact_mode` inherits `redact` from `config.toml` when left unset (`''`), so a config-only consumer can drive PDF redaction — and keep the links in lock-step — from config alone.
 
 ## Praxis control join
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -31,7 +31,19 @@ pub const Config = struct {
     current_year: u16,
     root: []const u8,
     is_draft: bool = false,
+    /// Whether the emitted PDFs are redacted (`{% redact() %}` spans masked and
+    /// a "(Redacted)" title suffix, so the on-disk name gains the `__Redacted__`
+    /// infix). Defaults from `[extra.policypress] redact`; `--redact` /
+    /// `--no-redact` override it (applied in main.zig). This is the state the
+    /// policy templates key their PDF link filenames off, so the links always
+    /// resolve to the files produced here (#159). Independent of `redact_web`.
     redact: bool = false,
+    /// Whether the website masks `{% redact() %}` blocks — the Zola templates'
+    /// `[extra.policypress] redact_web`. Parsed here only so the build can
+    /// preflight-warn when web masking and PDF redaction diverge (#159); it
+    /// never itself affects PDF output (#115: an org may mask the public site
+    /// while keeping full PDFs).
+    redact_web: bool = false,
     build_dir: []const u8,
     date: u.Date,
 
@@ -109,6 +121,7 @@ pub const Config = struct {
         try obj.put(alloc, "root", .{ .string = self.root });
         try obj.put(alloc, "is_draft", .{ .bool = self.is_draft });
         try obj.put(alloc, "redact", .{ .bool = self.redact });
+        try obj.put(alloc, "redact_web", .{ .bool = self.redact_web });
         try obj.put(alloc, "build_dir", .{ .string = self.build_dir });
         try obj.put(alloc, "review_overdue_days", .{ .integer = @intCast(self.review_overdue_days) });
         try obj.put(alloc, "report_pdfs", .{ .bool = self.report_pdfs });
@@ -175,12 +188,19 @@ pub const Config = struct {
         config.audit_bundle = e.getBool("audit_bundle") orelse false;
         config.build_dir = "public";
         config.zola_config = t;
-        // PDF redaction is controlled only by --redact/--no-redact (and the
-        // action's redact_mode input). `redact_web` is read by the Zola
-        // templates for the website's redaction bars and deliberately does
-        // not affect PDFs: an org may hide content (e.g. phone numbers) on
-        // the public site while keeping it in the PDFs. (#115)
-        config.redact = false;
+        // PDF redaction defaults from `[extra.policypress] redact` (#159), so a
+        // config-only consumer — e.g. via the GitHub Action — can enable it and
+        // keep the site's PDF links in lock-step with the files produced here.
+        // Off by default, preserving prior behavior. `--redact`/`--no-redact`
+        // still override this (applied in main.zig after load).
+        //
+        // This is independent of `redact_web`, which masks only the website's
+        // redaction bars and deliberately does not affect PDFs (#115: an org may
+        // hide content on the public site while keeping full PDFs). The two are
+        // preflight-compared (`reviewRedactionConsistency`) so a divergence is
+        // surfaced rather than silently shipping mismatched web/PDF output.
+        config.redact = e.getBool("redact") orelse false;
+        config.redact_web = e.getBool("redact_web") orelse false;
         return config;
     }
     pub fn deinit(self: *Config, alloc: Allocator) void {
@@ -264,6 +284,19 @@ pub const Config = struct {
     /// none < advisory < critical).
     fn maxKind(a: IssueKind, b: IssueKind) IssueKind {
         return if (@intFromEnum(a) >= @intFromEnum(b)) a else b;
+    }
+
+    /// Build-level preflight (#159): web redaction (`redact_web`, website-only
+    /// per #115) and PDF redaction (`redact`, the effective build state) are
+    /// independent knobs, but the policy templates now key the linked PDF
+    /// filename off `redact`, so the links always resolve regardless of
+    /// `redact_web`. When the two disagree the site is masked while the PDFs are
+    /// full (or vice versa) — supported (#115) but almost always unintended, and
+    /// on a public site it can leak the masked content through the published
+    /// PDF. Advisory, not fatal: the links still resolve. Returns `.none` when
+    /// the two agree.
+    pub fn reviewRedactionConsistency(self: Config) IssueKind {
+        return if (self.redact_web != self.redact) .advisory else .none;
     }
 
     /// Classify a policy by how long ago it was reviewed. `extra.last_reviewed`

--- a/src/main.zig
+++ b/src/main.zig
@@ -510,6 +510,26 @@ fn runBuild(io: std.Io, env: *EnvMap, alloc: Allocator, args: []const [:0]const 
                 .critical => critical += 1,
             }
         }
+        // #159: web-vs-PDF redaction consistency. The policy templates key the
+        // linked PDF filename off the effective PDF redaction state, so links
+        // resolve regardless of `redact_web`; but a build that masks the website
+        // while shipping full PDFs (or vice versa) is almost always a mistake
+        // and can leak the masked content through the public PDF. Advisory —
+        // #115 permits web-only masking — folded into the same counter.
+        switch (config.reviewRedactionConsistency()) {
+            .advisory => {
+                advisory += 1;
+                std.log.warn(
+                    "policypress: redact_web={} but PDFs are built redact={}; web masking and PDF " ++
+                        "redaction diverge. Supported (#115: mask the site, keep full PDFs) but usually " ++
+                        "unintended — a public site can leak the masked content through the PDF. Set " ++
+                        "[extra.policypress] redact to match redact_web (or pass --redact/--no-redact) to " ++
+                        "align them.",
+                    .{ config.redact_web, config.redact },
+                );
+            },
+            else => {},
+        }
         if (critical + advisory > 0) {
             std.log.warn(
                 "policypress: policy validation found {d} audit-critical and {d} advisory issue(s).",

--- a/src/test.zig
+++ b/src/test.zig
@@ -70,10 +70,12 @@ test "config loading and validation" {
     const alloc = tst.allocator;
     var conf = try config.load(io, alloc, TestConfig);
     defer conf.deinit(alloc);
-    // redact_web is web-only (Zola templates); PDF redaction comes solely
-    // from --redact/--no-redact. TestConfig sets redact_web = true, so this
-    // pins the decoupling (#115).
+    // TestConfig sets redact_web = true but no `redact` key: redact_web is
+    // web-only (#115) and does not by itself redact PDFs, and the config
+    // `redact` key (#159) defaults off. So the two are independent and PDF
+    // redaction is off here.
     try tst.expect(!conf.redact);
+    try tst.expect(conf.redact_web);
     alloc.free(conf.content_dir);
     conf.content_dir = try std.fs.path.join(alloc, &.{
         conf.root,
@@ -84,6 +86,106 @@ test "config loading and validation" {
     conf.policy_dir = try alloc.dupe(u8, conf.content_dir);
 
     try conf.validatePolicyFiles(io, alloc);
+}
+
+test "config: [extra.policypress] redact drives PDF redaction, independent of redact_web (#159)" {
+    const alloc = tst.allocator;
+
+    // Absent → off, preserving prior behavior (TestConfig has redact_web = true
+    // but no `redact` key).
+    {
+        var conf = try config.load(io, alloc, TestConfig);
+        defer conf.deinit(alloc);
+        try tst.expect(!conf.redact);
+        try tst.expect(conf.redact_web);
+    }
+
+    // `redact = true` turns PDF redaction on from config alone — the knob a
+    // config-only consumer (e.g. via the Action) uses to keep links in step.
+    {
+        var conf = try config.load(io, alloc, TestConfig ++ "\nredact = true\n");
+        defer conf.deinit(alloc);
+        try tst.expect(conf.redact);
+        try tst.expect(conf.redact_web);
+    }
+
+    // Independent of redact_web: web masking off, PDF redaction on.
+    {
+        const cfg =
+            \\base_url = "http://localhost:1111"
+            \\[extra.policypress]
+            \\redact_web = false
+            \\redact = true
+            \\policy_dir = "src/test"
+            \\organization = "Star City Security Consulting"
+            \\logo = "logo.png"
+            \\pdf_color = "#0e90f3"
+        ;
+        var conf = try config.load(io, alloc, cfg);
+        defer conf.deinit(alloc);
+        try tst.expect(conf.redact);
+        try tst.expect(!conf.redact_web);
+    }
+}
+
+test "preflight: redact_web vs PDF redaction divergence is advisory (#159)" {
+    const alloc = tst.allocator;
+    var conf = try config.load(io, alloc, TestConfig); // redact_web = true, redact = false
+    defer conf.deinit(alloc);
+
+    // Web masked but PDFs full → divergence (#115 permits it, flagged advisory).
+    try tst.expectEqual(config.IssueKind.advisory, conf.reviewRedactionConsistency());
+
+    // Aligned (both on) → clean.
+    conf.redact = true;
+    try tst.expectEqual(config.IssueKind.none, conf.reviewRedactionConsistency());
+
+    // Both off → clean.
+    conf.redact_web = false;
+    conf.redact = false;
+    try tst.expectEqual(config.IssueKind.none, conf.reviewRedactionConsistency());
+
+    // PDFs redacted but web full → also a divergence.
+    conf.redact = true;
+    try tst.expectEqual(config.IssueKind.advisory, conf.reviewRedactionConsistency());
+}
+
+test "link↔file: PDF link matches on-disk filename across redact_web × redact (#159)" {
+    const alloc = tst.allocator;
+    const f = try std.Io.Dir.cwd().openFile(io, "src/test/test_policy.md", .{});
+    defer f.close(io);
+    const raw = try utils.readAllAlloc(io, f, alloc, std.math.maxInt(usize));
+    defer alloc.free(raw);
+
+    var contents = Array(u8).empty; // get_metadata reads it read-only, so reuse
+    defer contents.deinit(alloc);
+    try contents.appendSlice(alloc, raw);
+
+    // The policy template keys the linked PDF filename off the effective PDF
+    // redaction state (`redact`), NOT `redact_web`; the on-disk name follows the
+    // same `redact` through get_metadata + FrontMatter.filename(). Assert the two
+    // agree for every (redact_web, redact) so a PDF link never 404s — and, by
+    // holding across both redact_web values, that redact_web is irrelevant to the
+    // filename (the #159 fix; before it the link followed redact_web).
+    inline for ([_]bool{ false, true }) |redact_web| {
+        _ = redact_web;
+        inline for ([_]bool{ false, true }) |redact| {
+            var fm = try utils.get_metadata(alloc, &contents, .{ .redact = redact, .is_draft = false });
+            defer fm.deinit(alloc);
+            const on_disk = try fm.filename(alloc);
+            defer alloc.free(on_disk);
+
+            // Mirror templates/policies/page.html: slug(title) ~ infix ~ version.
+            // slug("Test Policy") == "Test_Policy"; the newest revision is v1.1.
+            const link = if (redact)
+                try std.fmt.allocPrint(alloc, "Test_Policy__Redacted__-_v{s}.pdf", .{fm.most_recent_version})
+            else
+                try std.fmt.allocPrint(alloc, "Test_Policy_-_v{s}.pdf", .{fm.most_recent_version});
+            defer alloc.free(link);
+
+            try tst.expectEqualStrings(link, on_disk);
+        }
+    }
 }
 
 test "review preflight flags overdue policies" {

--- a/starter/config.toml
+++ b/starter/config.toml
@@ -75,9 +75,17 @@ policy_dir = "policies/"
 
 # Renders a redaction bar over {% redact() %}...{% end %} blocks on the *website*.
 # Defaults to true because this starter auto-deploys to public GitHub Pages: with
-# it off, redacted content would ship in the site's HTML and search index. Does
-# not affect PDFs — use --redact (redact_mode in the action) for those.
+# it off, redacted content would ship in the site's HTML and search index.
+# Web-only (#115); does not itself affect PDFs.
 redact_web = true
+
+# Redact the *PDFs* too (mask {% redact() %} spans and add the "__Redacted__"
+# filename infix). Defaults to true here for the same reason as redact_web: the
+# PDFs are published to the same public Pages site, so leaving them full would
+# leak the masked content. Keep this in step with redact_web so the site's PDF
+# links resolve (#159). --redact/--no-redact (redact_mode in the action)
+# override it.
+redact = true
 
 # Set to true to stamp all PDFs with a DRAFT watermark by default.
 # Can be overridden per-run with --draft / --no-draft.

--- a/templates/policies/page.html
+++ b/templates/policies/page.html
@@ -11,7 +11,12 @@
 {% set versions = page.extra.major_revisions | sort(attribute="date") | reverse %}
 {% set current_version = versions | first %}
 {%- set title_slug = macros_pdf::slug(title=page.title) | trim -%}
-{%- if config.extra.policypress.redact_web -%}
+{# Key the linked PDF name off the effective PDF redaction state
+   (`[extra.policypress] redact`), NOT `redact_web`: the on-disk name gains the
+   "__Redacted__" infix only when the PDF itself is redacted, so keying off
+   `redact` keeps the link and the file in lock-step (#159). `redact_web` masks
+   only the website (#115) and must never drive the PDF filename here. #}
+{%- if config.extra.policypress.redact | default(value=false) -%}
   {%- set pdf_official = title_slug ~ "__Redacted__-_v" ~ current_version.version ~ ".pdf" -%}
 {%- else -%}
   {%- set pdf_official = title_slug ~ "_-_v" ~ current_version.version ~ ".pdf" -%}
@@ -45,8 +50,12 @@ reverse %}
 {% set review_overdue = (today - last_reviewed_ts) > 31557600 %}
 
 {%- set title_slug = macros_pdf::slug(title=page.title) | trim -%}
-{# The binary sanitises '(' and ')' to '_', so (Redacted) becomes __Redacted__ #}
-{%- if config.extra.policypress.redact_web -%}
+{# Key the linked PDF names off the effective PDF redaction state
+   (`[extra.policypress] redact`), NOT `redact_web` (#159). The binary sanitises
+   '(' and ')' to '_', so a redacted PDF's "(Redacted)" title suffix becomes the
+   "__Redacted__" infix on disk; mirroring the same condition here keeps the
+   links and files in lock-step. `redact_web` masks only the website (#115). #}
+{%- if config.extra.policypress.redact | default(value=false) -%}
   {%- set pdf_official = title_slug ~ "__Redacted__-_v" ~ current_version.version ~ ".pdf" -%}
   {%- set pdf_draft = title_slug ~ "__Redacted___Draft__-_v" ~ current_version.version ~ ".pdf" -%}
 {%- else -%}


### PR DESCRIPTION
## The bug

`templates/policies/page.html` keyed the **linked** PDF filename off
`config.extra.policypress.redact_web`, but the **on-disk** filename
(`FrontMatter.filename()` in `src/utils.zig`) gains the `__Redacted__` infix only
when the PDF is actually redacted (`config.redact`, i.e. `--redact`). Since #115
made `redact_web` deliberately web-only, the link name followed `redact_web`
while the file name followed `--redact`; whenever they differed, every policy PDF
link 404'd.

Repro (the #115-supported combination): `redact_web = true`, build **without**
`--redact` -> link `…__Redacted__-_v1.1.pdf`, file `…_-_v1.1.pdf` -> 404.

## The fix (keeps #115's web/PDF independence)

The link now reflects the **actual redaction state of the emitted PDF**, not
`redact_web`:

1. **Template** — `pdf_official`/`pdf_draft` key off `[extra.policypress] redact`
   (the effective PDF redaction state), mirroring the exact `__Redacted__`
   condition `FrontMatter.filename()` uses, so link and file always agree.
   `redact_web` still drives the website's redaction bars (`redact.html`).
2. **Config knob** — `src/config.zig` parses a new `redact` key (default
   `false`, preserving prior behavior) so a config-only consumer (e.g. via the
   Action) can drive PDF redaction and keep links in lock-step. `--redact` /
   `--no-redact` still override. `redact_web` is now parsed too, for the
   preflight.
3. **Preflight guard** — an advisory (folded into the existing preflight
   counter) fires when `redact_web` and the effective PDF redaction diverge:
   supported per #115 (mask the site, keep full PDFs) but almost always a
   mistake, and on a public site it can leak the masked content through the PDF.
   The links still resolve (they follow `redact`), so it is a warning, not an
   error.
4. **Action** — `redact_mode` now inherits `[extra.policypress] redact` when
   unset (`''`), so config-only redaction actually reaches the build; an
   explicit `true`/`false` still overrides. (`deploy-docs.yml` / `preview.yml`
   set it explicitly, so they are unchanged.)
5. **Demo + starter configs** set `redact = true` — their deployments already
   redact (`redact_mode: true`), so this keeps web + PDF + links consistent and
   documents the knob by example.
6. **Docs** — `content/guides/configuration.md` documents `redact` and the
   keep-in-step guidance.

## Verified matrix (link vs on-disk file)

| `redact_web` | `redact` | link name | file name | result |
|---|---|---|---|---|
| true  | true  | `__Redacted__` | `__Redacted__` | agree |
| true  | false | plain          | plain          | agree (advisory warns) — **the repro** |
| false | true  | `__Redacted__` | `__Redacted__` | agree (advisory warns) |
| false | false | plain          | plain          | agree |

Before/after of the repro (`redact_web = true`, no `--redact`):

- before: link `Acceptable_Use_Policy__Redacted__-_v1.0.pdf`, file
  `Acceptable_Use_Policy_-_v1.0.pdf` -> 404
- after: link and file are both `Acceptable_Use_Policy_-_v1.0.pdf` -> resolves

Reproduced end-to-end (`zola build` + `policypress` with no `--redact`): links
match on-disk files, and the preflight advisory fires.

## Tests

`src/test.zig`: link<->file agreement across the `redact_web × redact` matrix;
the new `redact` config-key parse (independent of `redact_web`); and the
mismatch preflight advisory (`reviewRedactionConsistency`).

`zig build test`, `zig build e2e`, and
`nix build .#checks.x86_64-linux.zola-check` all pass.

Closes #159
