### PR TITLE
refactor: isolate praxis as an optional overlay; praxis-free 'See also' footnotes (#174, #172)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -346,6 +346,29 @@
                   touch $out
                 '';
 
+            # praxis is an OPTIONAL overlay (#174): with no `praxis_join`
+            # configured, the rendered site must contain ZERO praxis-overlay
+            # markup, so praxis is provably removable. Build the demo web output
+            # with `praxis_join` commented out and grep the HTML for the overlay
+            # tokens; any hit fails. (Bare "praxis" in authored guide prose is
+            # fine — only the overlay's own class/marker tokens are checked.)
+            checks.praxis-optional =
+              pkgs.runCommand "praxis-optional"
+                {
+                  nativeBuildInputs = [ pkgs.zola ];
+                }
+                ''
+                  cp -r ${zolaCheckSrc}/. .
+                  chmod -R u+w .
+                  sed -i 's/^praxis_join =/# praxis_join =/' config.toml
+                  zola build --output-dir public
+                  if grep -rE 'praxis-badge|satisfies-tag--praxis|control-ref--praxis|In praxis control spine|praxis spine coverage' public --include='*.html'; then
+                    echo "praxis overlay markup found in the rendered site despite no praxis_join (#174 invariant violated)." >&2
+                    exit 1
+                  fi
+                  touch $out
+                '';
+
             # Validate the tagged PDFs actually conform to PDF/UA-1, using
             # veraPDF (the PDF Association's reference validator). Builds the
             # demo policies (config.toml has pdf_standard = "ua-1") and fails if

--- a/sass/components/_praxis.scss
+++ b/sass/components/_praxis.scss
@@ -1,0 +1,76 @@
+// praxis overlay styles — OPTIONAL, in-repo (issue #174).
+//
+// All praxis-specific presentation lives here, behind the overlay boundary in
+// main.scss, so the core `_satisfies.scss` styles stay praxis-agnostic. These
+// modifiers decorate base classes defined in `_satisfies.scss`
+// (`.satisfies-tag`, `.control-ref`), so this partial is imported after it.
+// The rules are inert until the praxis overlay templates emit the matching
+// classes (which they only do when a `praxis_join` is configured).
+//
+// The `--pp-praxis` / `--pp-praxis-subtle` colour tokens are defined with the
+// rest of the palette in `common/_dark.scss`; a distinct teal so an "in praxis
+// spine" marker never reads as a normal link.
+
+// praxis spine marker on a framework tag. Not colour-only: a leading dot plus a
+// thin accent border make the "in spine" state legible without relying on hue,
+// and the markup carries a `title` tooltip. The dot uses --pp-praxis, which
+// clears AA 4.5:1 on the tag background in both themes.
+.satisfies-tag--praxis {
+  border-left: 3px solid var(--pp-praxis);
+  padding-left: 0.4rem;
+
+  &::before {
+    content: "";
+    display: inline-block;
+    width: 0.4rem;
+    height: 0.4rem;
+    margin-right: 0.35rem;
+    border-radius: 50%;
+    background: var(--pp-praxis);
+    vertical-align: middle;
+  }
+}
+
+// praxis spine marker for an inline control reference. Leading dot (not
+// colour-only), paired with the `title` tooltip in the markup. --pp-praxis
+// clears AA 4.5:1 as a dot against the page background in both themes.
+.control-ref--praxis::before {
+  content: "";
+  display: inline-block;
+  width: 0.4rem;
+  height: 0.4rem;
+  margin-right: 0.25rem;
+  border-radius: 50%;
+  background: var(--pp-praxis);
+  vertical-align: baseline;
+}
+
+// "praxis" badge shown per control on the SCF report/single pages. A bordered
+// pill with a leading dot; text + border + dot all use --pp-praxis (AA 4.5:1 on
+// the card background in both themes) so it never depends on colour alone.
+.praxis-badge {
+  display: inline-block;
+  margin-left: 0.4rem;
+  padding: 0.05rem 0.45rem;
+  border: 1px solid var(--pp-praxis);
+  border-radius: var(--pp-radius-pill, 50px);
+  background: var(--pp-praxis-subtle);
+  color: var(--pp-praxis);
+  font-family: $font-family-monospace;
+  font-size: 0.7em;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  vertical-align: middle;
+  white-space: nowrap;
+
+  &::before {
+    content: "";
+    display: inline-block;
+    width: 0.4rem;
+    height: 0.4rem;
+    margin-right: 0.3rem;
+    border-radius: 50%;
+    background: var(--pp-praxis);
+    vertical-align: middle;
+  }
+}

--- a/sass/components/_satisfies.scss
+++ b/sass/components/_satisfies.scss
@@ -67,26 +67,6 @@
   }
 }
 
-// praxis spine marker on a framework tag. Not colour-only: a leading dot plus a
-// thin accent border make the "in spine" state legible without relying on hue,
-// and the markup carries a `title` tooltip. The dot uses --pp-praxis, which
-// clears AA 4.5:1 on the tag background in both themes.
-.satisfies-tag--praxis {
-  border-left: 3px solid var(--pp-praxis);
-  padding-left: 0.4rem;
-
-  &::before {
-    content: "";
-    display: inline-block;
-    width: 0.4rem;
-    height: 0.4rem;
-    margin-right: 0.35rem;
-    border-radius: 50%;
-    background: var(--pp-praxis);
-    vertical-align: middle;
-  }
-}
-
 // Inline control reference produced by the {{ control(id="…") }} shortcode.
 // Subtle enough to sit inside body prose without shouting, but still clearly a
 // link. Monospace matches the framework-tag treatment so ids read as ids.
@@ -110,50 +90,6 @@ a.control-ref {
   &:focus {
     color: var(--bs-link-hover-color);
     text-decoration: none;
-  }
-}
-
-// praxis spine marker for an inline control reference. Leading dot (not
-// colour-only), paired with the `title` tooltip in the markup. --pp-praxis
-// clears AA 4.5:1 as a dot against the page background in both themes.
-.control-ref--praxis::before {
-  content: "";
-  display: inline-block;
-  width: 0.4rem;
-  height: 0.4rem;
-  margin-right: 0.25rem;
-  border-radius: 50%;
-  background: var(--pp-praxis);
-  vertical-align: baseline;
-}
-
-// "praxis" badge shown per control on the SCF report/single pages. A bordered
-// pill with a leading dot; text + border + dot all use --pp-praxis (AA 4.5:1 on
-// the card background in both themes) so it never depends on colour alone.
-.praxis-badge {
-  display: inline-block;
-  margin-left: 0.4rem;
-  padding: 0.05rem 0.45rem;
-  border: 1px solid var(--pp-praxis);
-  border-radius: var(--pp-radius-pill, 50px);
-  background: var(--pp-praxis-subtle);
-  color: var(--pp-praxis);
-  font-family: $font-family-monospace;
-  font-size: 0.7em;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  vertical-align: middle;
-  white-space: nowrap;
-
-  &::before {
-    content: "";
-    display: inline-block;
-    width: 0.4rem;
-    height: 0.4rem;
-    margin-right: 0.3rem;
-    border-radius: 50%;
-    background: var(--pp-praxis);
-    vertical-align: middle;
   }
 }
 

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -28,6 +28,11 @@
 @import "components/reports";
 @import "components/tabs";
 @import "components/satisfies";
+// praxis overlay (optional, #174): spine markers/badge styling, kept in its own
+// partial behind this boundary. Decorates the base classes in `satisfies`, so
+// it is imported after it; inert until the praxis overlay templates emit the
+// matching classes (only when a praxis_join is configured).
+@import "components/praxis";
 @import "components/search";
 @import "components/section-cards";
 @import "components/syntax";

--- a/src/controls.zig
+++ b/src/controls.zig
@@ -3,27 +3,36 @@
 //!
 //! Control-ID join for policy PDFs (#127 / #164).
 //!
-//! Binds three read-only data sources so that inline control references become
+//! Binds two read-only data sources so that inline control references become
 //! footnotes carrying auditable context:
 //!
 //!   * the SCF control catalog (`data/scf.json`, via `control_report.zig`) — the
-//!     control title;
-//!   * the optional praxis join (`data/praxis-join.json`) — whether the control
-//!     is in praxis's actively-governed spine; and
+//!     control title; and
 //!   * a `zigmark.Library` of the non-draft policies — the render-time reverse
 //!     lookup (control id → covering policy titles) that exists nowhere else.
 //!
-//! `ControlJoin` produces a `zigmark.footnotes.Resolver`: given a control label
-//! like `IAC-01`, it returns the Markdown definition body that
-//! `zigmark.footnotes.resolve` synthesises into the AST, which the Typst
-//! renderer then expands to a native `#footnote[…]`. Every clause degrades: a
-//! missing catalog drops the title, a missing join drops the praxis clause, no
-//! covering policy drops that clause — the id alone is always a valid footnote.
+//! The footnote body is **praxis-agnostic** (#172/#174): praxis spine
+//! membership is an optional overlay surfaced on the web badges, the PDF
+//! coverage annex, and `audit/join.json` — never repeated inline in every
+//! footnote. The one residual praxis touch in this file is a load-time catalog
+//! skew diagnostic, quarantined behind `checkPraxisCatalogSkew` (see below); it
+//! reads the join purely to warn, and does not shape any rendered output.
+//!
+//! `ControlJoin` produces a per-document `zigmark.footnotes.Resolver` (via
+//! `DocResolver`): given a control label like `IAC-01`, it returns the Markdown
+//! definition body that `zigmark.footnotes.resolve` synthesises into the AST,
+//! which the Typst renderer then expands to a native `#footnote[…]`. Shape:
+//! `IAC-01 — <title>. See also: <other covering policies>.` — every clause
+//! degrades: a missing catalog drops the title, and no *other* covering policy
+//! drops the "See also" clause (the id alone is always a valid footnote). The
+//! resolver is per-document so "See also" can exclude the policy that owns the
+//! footnote (it never lists itself).
 //!
 //! `ControlJoin` is additive: it never touches `control_report.zig`'s
 //! `coverage()`, whose draft-exclusion / dedup / corrected-numerator logic stays
 //! canonical. After construction it is read-only, so a single instance is shared
-//! (by resolver value) across the concurrent per-policy compile tasks.
+//! across the concurrent per-policy compile tasks; each task wraps it in its own
+//! stack-local `DocResolver` bound to that policy's path.
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
@@ -85,7 +94,11 @@ pub const ControlJoin = struct {
     /// `taxonomies.TSC2017` criteria); footnote resolution and validation are
     /// SCF-only.
     tsc_catalog: ?reports,
-    /// praxis spine membership, or null when no join file is configured.
+    /// The optional praxis join — the SINGLE praxis seam in this core type.
+    /// Held only to drive the load-time catalog-skew diagnostic
+    /// (`checkPraxisCatalogSkew`); it is deliberately *not* read by
+    /// `resolveFootnote` (footnotes are praxis-agnostic, #172/#174). Null when
+    /// no join file is configured, so a praxis-free build touches none of it.
     join: ?praxis_join.PraxisJoin,
     /// The non-draft policies, queried for covering-policy titles.
     library: zigmark.Library,
@@ -138,20 +151,7 @@ pub const ControlJoin = struct {
         errdefer if (join) |*j| j.deinit();
         if (join_path) |jp| {
             join = try praxis_join.PraxisJoin.load(io, alloc, jp);
-            // A configured catalog and join built from different SCF versions is a
-            // maintenance smell: spine ids the local catalog does not know cannot
-            // be titled. Advisory, so builds still pass (SCF-version skew is the
-            // author's to reconcile, not a hard failure).
-            if (catalog) |*c| {
-                for (join.?.ids) |id| {
-                    if (!c.map.contains(id)) {
-                        ctrllog.warn(
-                            "praxis spine id '{s}' is not in the local control catalog (SCF version skew)",
-                            .{id},
-                        );
-                    }
-                }
-            }
+            checkPraxisCatalogSkew(join.?, if (catalog) |*c| c else null);
         }
 
         var library = zigmark.Library.init(alloc);
@@ -178,15 +178,18 @@ pub const ControlJoin = struct {
         self.library.deinit();
     }
 
-    /// A `zigmark.footnotes.Resolver` bound to this join. The returned resolver
-    /// borrows `self`; it must not outlive the `ControlJoin`.
-    pub fn resolver(self: *const ControlJoin) zigmark.footnotes.Resolver {
-        return .{ .ctx = @constCast(self), .resolveFn = resolveThunk };
-    }
-
-    fn resolveThunk(ctx: ?*anyopaque, alloc: Allocator, label: []const u8) anyerror!?[]const u8 {
-        const self: *const ControlJoin = @ptrCast(@alignCast(ctx.?));
-        return self.resolveFootnote(alloc, label);
+    /// Build a per-document footnote resolver bound to this join and to
+    /// `self_path` — the path (relative to `config.root`) of the policy being
+    /// compiled. "See also" cross-references exclude that policy so a footnote
+    /// never lists the document it lives in. Pass null for a document-agnostic
+    /// resolver (every covering policy is listed).
+    ///
+    /// The returned `DocResolver` borrows both `self` and `self_path`; keep it
+    /// alive for the whole compile. Because compilation is concurrent across
+    /// policies, each task must build (and own) its own `DocResolver` — never
+    /// share one mutable instance.
+    pub fn docResolver(self: *const ControlJoin, self_path: ?[]const u8) DocResolver {
+        return .{ .join = self, .self_path = self_path };
     }
 
     /// A `control_annex.Provider` bound to this join, for the PDF control-coverage
@@ -220,11 +223,21 @@ pub const ControlJoin = struct {
     /// not a control id (so a genuinely unknown footnote reference stays
     /// dangling for validation to catch). Shape:
     ///
-    ///   `IAC-01 — <title>. praxis: in control spine. Covered by: A, B.`
+    ///   `IAC-01 — <title>. See also: A, B.`
     ///
-    /// with any clause omitted when its data source is absent. Caller owns the
-    /// returned slice (zigmark frees it, per the resolver contract).
-    pub fn resolveFootnote(self: *const ControlJoin, alloc: Allocator, label: []const u8) !?[]const u8 {
+    /// The body is praxis-agnostic (#172/#174): no spine clause. "See also"
+    /// lists the *other* non-draft policies that address the control (excluding
+    /// `self_path`, the policy that owns the footnote); it is omitted entirely
+    /// when no other policy covers the control, and the title clause is omitted
+    /// when the catalog is absent (the id alone is always a valid footnote).
+    /// Caller owns the returned slice (zigmark frees it, per the resolver
+    /// contract).
+    pub fn resolveFootnote(
+        self: *const ControlJoin,
+        alloc: Allocator,
+        label: []const u8,
+        self_path: ?[]const u8,
+    ) !?[]const u8 {
         if (!isControlId(label)) return null;
 
         var aw: std.Io.Writer.Allocating = .init(alloc);
@@ -239,19 +252,13 @@ pub const ControlJoin = struct {
         }
         try aw.writer.writeByte('.');
 
-        // praxis spine clause (only when a join is configured).
-        if (self.join) |*j| {
-            try aw.writer.print(" praxis: {s}.", .{
-                if (j.contains(label)) "in control spine" else "not in control spine",
-            });
-        }
-
-        // Covering-policy clause (only when ≥1 non-draft policy tags the control).
-        const covering = try self.coveringPolicies(alloc, label);
-        defer alloc.free(covering);
-        if (covering.len > 0) {
-            try aw.writer.writeAll(" Covered by: ");
-            for (covering, 0..) |title, i| {
+        // "See also" clause: the OTHER non-draft policies tagging this control,
+        // excluding the current one. Omitted when no other policy covers it.
+        const also = try self.coveringPolicies(alloc, label, self_path);
+        defer alloc.free(also);
+        if (also.len > 0) {
+            try aw.writer.writeAll(" See also: ");
+            for (also, 0..) |title, i| {
                 if (i > 0) try aw.writer.writeAll(", ");
                 try aw.writer.writeAll(title);
             }
@@ -262,10 +269,16 @@ pub const ControlJoin = struct {
     }
 
     /// Sorted, deduplicated titles of the non-draft policies whose
-    /// `taxonomies.SCF` lists `label`. The returned slice is owned by the caller
+    /// `taxonomies.SCF` lists `label`, excluding the policy at `exclude_path`
+    /// (pass null to exclude none). The returned slice is owned by the caller
     /// (`alloc.free`); its elements borrow from the library's frontmatter, which
     /// lives for the whole build.
-    fn coveringPolicies(self: *const ControlJoin, alloc: Allocator, label: []const u8) ![]const []const u8 {
+    fn coveringPolicies(
+        self: *const ControlJoin,
+        alloc: Allocator,
+        label: []const u8,
+        exclude_path: ?[]const u8,
+    ) ![]const []const u8 {
         const q = try std.fmt.allocPrint(alloc, "taxonomies.SCF={s}", .{label});
         defer alloc.free(q);
 
@@ -275,6 +288,12 @@ pub const ControlJoin = struct {
         var titles = std.ArrayList([]const u8).empty;
         errdefer titles.deinit(alloc);
         for (results) |r| {
+            // Skip the current policy so its own footnotes never list it.
+            if (exclude_path) |ep| {
+                if (r.entry.path) |rp| {
+                    if (std.mem.eql(u8, rp, ep)) continue;
+                }
+            }
             const fm = r.entry.frontmatter orelse continue;
             const title_v = fm.get("title") orelse continue;
             if (title_v != .string) continue;
@@ -514,7 +533,7 @@ pub const ControlJoin = struct {
             // Cross-policy cover/exclude conflict → advisory. Only meaningful for
             // well-formed ids; a covering policy other than this one is the tension.
             if (isControlId(eid)) {
-                const covering = self.coveringPolicies(alloc, eid) catch &.{};
+                const covering = self.coveringPolicies(alloc, eid, null) catch &.{};
                 defer alloc.free(covering);
                 for (covering) |title| {
                     if (!std.mem.eql(u8, title, own_title)) {
@@ -534,6 +553,49 @@ pub const ControlJoin = struct {
 
 fn lessThanStr(_: void, lhs: []const u8, rhs: []const u8) bool {
     return std.mem.order(u8, lhs, rhs) == .lt;
+}
+
+/// A per-document `zigmark.footnotes.Resolver` context: a borrowed
+/// `*const ControlJoin` plus the path of the policy currently being compiled.
+/// The resolver's opaque `ctx` is a single pointer, so this small struct is the
+/// per-document ctx — one is built (on the stack) per concurrent compile task,
+/// bound to that task's policy, so "See also" can exclude the owning document
+/// without any shared mutable state. Build via `ControlJoin.docResolver`.
+pub const DocResolver = struct {
+    join: *const ControlJoin,
+    /// Path (relative to `config.root`) of the policy being compiled, excluded
+    /// from its own "See also" cross-references. Null lists every covering
+    /// policy (document-agnostic).
+    self_path: ?[]const u8,
+
+    /// The `zigmark.footnotes.Resolver` view. Borrows `self`; the `DocResolver`
+    /// must outlive every use of the returned resolver.
+    pub fn resolver(self: *const DocResolver) zigmark.footnotes.Resolver {
+        return .{ .ctx = @constCast(self), .resolveFn = resolveThunk };
+    }
+
+    fn resolveThunk(ctx: ?*anyopaque, alloc: Allocator, label: []const u8) anyerror!?[]const u8 {
+        const self: *const DocResolver = @ptrCast(@alignCast(ctx.?));
+        return self.join.resolveFootnote(alloc, label, self.self_path);
+    }
+};
+
+/// The one praxis touch in this core module: a load-time diagnostic warning
+/// when the configured catalog and praxis join were built from different SCF
+/// versions (a spine id the local catalog does not know cannot be titled).
+/// Advisory only — it logs and never shapes rendered output, so a praxis-free
+/// build (no join) never reaches it. Quarantined here so `resolveFootnote` and
+/// the rest of `ControlJoin` stay praxis-agnostic (#174).
+fn checkPraxisCatalogSkew(join: praxis_join.PraxisJoin, catalog: ?*const reports) void {
+    const cat = catalog orelse return;
+    for (join.ids) |id| {
+        if (!cat.map.contains(id)) {
+            ctrllog.warn(
+                "praxis spine id '{s}' is not in the local control catalog (SCF version skew)",
+                .{id},
+            );
+        }
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/src/golden.zig
+++ b/src/golden.zig
@@ -58,20 +58,28 @@ pub fn renderControlFixture(io: std.Io, alloc: std.mem.Allocator) ![]u8 {
     conf.current_year = 2026;
 
     const fixture = "src/test/test_policy_controls.md";
+    // A second policy that also addresses IAC-01, so the rendered fixture's
+    // IAC-01 footnote carries a "See also" cross-reference to it — while DCH-01
+    // (covered only by the fixture itself) shows the clause omitted.
+    const related = "src/test/test_policy_controls_related.md";
     var cj = try controls.ControlJoin.init(
         io,
         alloc,
         "src/test/controls_catalog.json",
         "src/test/controls_tsc_catalog.json",
         "src/test/controls_join.json",
-        &.{fixture},
+        &.{ fixture, related },
     );
     defer cj.deinit();
 
     // Pass BOTH the footnote resolver (inline control(...) refs) and the annex
     // provider (frontmatter framework tags + scope exclusions), so the baseline
-    // exercises the full #164+#165 render path.
-    var rendered = try typst.renderWithControls(io, alloc, conf, fixture, cj.resolver(), cj.annexProvider());
+    // exercises the full #164+#165 render path. The resolver is per-document
+    // (bound to the fixture's own path) so "See also" excludes the fixture
+    // itself — the fixture is the sole library policy, so its footnotes carry no
+    // "See also" clause.
+    var doc_resolver = cj.docResolver(fixture);
+    var rendered = try typst.renderWithControls(io, alloc, conf, fixture, doc_resolver.resolver(), cj.annexProvider());
     defer rendered.deinit(alloc);
     return alloc.dupe(u8, rendered.source);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -487,7 +487,10 @@ fn runBuild(io: std.Io, env: *EnvMap, alloc: Allocator, args: []const [:0]const 
         policy_paths,
     );
     defer control_join.deinit();
-    const control_resolver: ?zigmark.footnotes.Resolver = control_join.resolver();
+    // The footnote resolver is now built PER DOCUMENT inside `compileOne` (a
+    // stack-local `DocResolver` bound to that policy's path, so "See also"
+    // excludes the owning policy). The annex provider stays a single read-only
+    // value shared across the concurrent compile tasks.
     const control_annex_provider: ?control_annex.Provider = control_join.annexProvider();
 
     // --- Front-matter validation (pre-flight) ---
@@ -617,7 +620,7 @@ fn runBuild(io: std.Io, env: *EnvMap, alloc: Allocator, args: []const [:0]const 
             alloc,
             config,
             p.path,
-            control_resolver,
+            &control_join,
             control_annex_provider,
             stamps_dir_path,
             compile_node,
@@ -940,7 +943,7 @@ fn compileOne(
     alloc: Allocator,
     config: Config,
     input_path: []const u8,
-    resolver: ?zigmark.footnotes.Resolver,
+    control_join: *const controls.ControlJoin,
     annex_provider: ?control_annex.Provider,
     stamps_dir: []const u8,
     progress_node: std.Progress.Node,
@@ -949,6 +952,12 @@ fn compileOne(
     error_list: *std.ArrayList(ErrorInfo),
 ) void {
     defer progress_node.completeOne();
+
+    // Per-document footnote resolver: a stack-local bound to this policy's path
+    // so its own "See also" cross-references exclude it. Owned by this task; no
+    // shared mutable resolver across the concurrent compiles.
+    var doc_resolver = control_join.docResolver(input_path);
+    const resolver: ?zigmark.footnotes.Resolver = doc_resolver.resolver();
 
     Typst.compile(io, env, alloc, config, input_path, resolver, annex_provider) catch |err| {
         error_mutex.lockUncancelable(io);

--- a/src/test.zig
+++ b/src/test.zig
@@ -1629,8 +1629,10 @@ test "praxis join: missing schema field is a hard, distinct error" {
 // ── Control-ID join (src/controls.zig) ────────────────────────────────────────
 
 /// A ControlJoin over the committed fixtures: catalog IAC-01/DCH-01/NET-02,
-/// spine {IAC-01, NET-02}, library = the single control fixture policy (tags
-/// IAC-01 + DCH-01, titled "Access Control Test Policy").
+/// spine {IAC-01, NET-02}, library = two control fixture policies — the primary
+/// ("Access Control Test Policy", tags IAC-01 + DCH-01) and a related policy
+/// ("Access Control Standard", tags IAC-01), so "See also" cross-references have
+/// another policy to point at.
 fn fixtureControlJoin(alloc: Allocator) !controls.ControlJoin {
     return controls.ControlJoin.init(
         io,
@@ -1638,45 +1640,64 @@ fn fixtureControlJoin(alloc: Allocator) !controls.ControlJoin {
         "src/test/controls_catalog.json",
         "src/test/controls_tsc_catalog.json",
         "src/test/controls_join.json",
-        &.{"src/test/test_policy_controls.md"},
+        &.{ "src/test/test_policy_controls.md", "src/test/test_policy_controls_related.md" },
     );
 }
 
-test "controls: resolveFootnote — covered + in spine" {
+/// The primary fixture policy, used as the "self" excluded from its own
+/// "See also" cross-references.
+const fixture_self = "src/test/test_policy_controls.md";
+
+test "controls: resolveFootnote — praxis-free, 'See also' lists OTHER covering policies (excludes self)" {
     const alloc = tst.allocator;
     var cj = try fixtureControlJoin(alloc);
     defer cj.deinit();
 
-    const md = (try cj.resolveFootnote(alloc, "IAC-01")).?;
+    // IAC-01 is tagged by the primary fixture (self) and the related policy.
+    // Rendered from the primary fixture, "See also" names only the related one.
+    const md = (try cj.resolveFootnote(alloc, "IAC-01", fixture_self)).?;
     defer alloc.free(md);
     try tst.expect(std.mem.startsWith(u8, md, "IAC-01 \u{2014} Identity & Access Management."));
-    try tst.expect(std.mem.indexOf(u8, md, "praxis: in control spine.") != null);
-    try tst.expect(std.mem.indexOf(u8, md, "Covered by: Access Control Test Policy.") != null);
+    try tst.expect(std.mem.indexOf(u8, md, "See also: Access Control Standard.") != null);
+    // No praxis clause, and the policy never lists itself.
+    try tst.expect(std.mem.indexOf(u8, md, "praxis") == null);
+    try tst.expect(std.mem.indexOf(u8, md, "Access Control Test Policy") == null);
 }
 
-test "controls: resolveFootnote — covered but not in spine" {
+test "controls: resolveFootnote — 'See also' omitted when self is the only coverer" {
     const alloc = tst.allocator;
     var cj = try fixtureControlJoin(alloc);
     defer cj.deinit();
 
-    const md = (try cj.resolveFootnote(alloc, "DCH-01")).?;
+    // DCH-01 is tagged only by the primary fixture; excluding self leaves no
+    // other policy, so the clause is dropped entirely — just id + title.
+    const md = (try cj.resolveFootnote(alloc, "DCH-01", fixture_self)).?;
     defer alloc.free(md);
-    try tst.expect(std.mem.indexOf(u8, md, "DCH-01 \u{2014} Data Protection.") != null);
-    try tst.expect(std.mem.indexOf(u8, md, "praxis: not in control spine.") != null);
-    try tst.expect(std.mem.indexOf(u8, md, "Covered by: Access Control Test Policy.") != null);
+    try tst.expectEqualStrings("DCH-01 \u{2014} Data Protection.", md);
 }
 
-test "controls: resolveFootnote — in spine but uncovered omits the Covered-by clause" {
+test "controls: resolveFootnote — null self_path lists every covering policy, sorted" {
     const alloc = tst.allocator;
     var cj = try fixtureControlJoin(alloc);
     defer cj.deinit();
 
-    const md = (try cj.resolveFootnote(alloc, "NET-02")).?;
+    // Document-agnostic resolver: both policies covering IAC-01 are listed.
+    const md = (try cj.resolveFootnote(alloc, "IAC-01", null)).?;
     defer alloc.free(md);
-    try tst.expect(std.mem.indexOf(u8, md, "NET-02 \u{2014} Layered Network Defenses.") != null);
-    try tst.expect(std.mem.indexOf(u8, md, "praxis: in control spine.") != null);
-    // No policy tags NET-02, so there is no covering clause.
-    try tst.expect(std.mem.indexOf(u8, md, "Covered by:") == null);
+    try tst.expect(std.mem.indexOf(u8, md, "See also: Access Control Standard, Access Control Test Policy.") != null);
+    try tst.expect(std.mem.indexOf(u8, md, "praxis") == null);
+}
+
+test "controls: resolveFootnote — an uncovered control has no 'See also' clause" {
+    const alloc = tst.allocator;
+    var cj = try fixtureControlJoin(alloc);
+    defer cj.deinit();
+
+    // No policy tags NET-02, so the footnote is just id + title (no praxis, even
+    // though NET-02 is in the spine).
+    const md = (try cj.resolveFootnote(alloc, "NET-02", fixture_self)).?;
+    defer alloc.free(md);
+    try tst.expectEqualStrings("NET-02 \u{2014} Layered Network Defenses.", md);
 }
 
 test "controls: resolveFootnote — a non-control label returns null" {
@@ -1684,27 +1705,22 @@ test "controls: resolveFootnote — a non-control label returns null" {
     var cj = try fixtureControlJoin(alloc);
     defer cj.deinit();
 
-    try tst.expect((try cj.resolveFootnote(alloc, "not-a-control")) == null);
-    try tst.expect((try cj.resolveFootnote(alloc, "1")) == null);
+    try tst.expect((try cj.resolveFootnote(alloc, "not-a-control", fixture_self)) == null);
+    try tst.expect((try cj.resolveFootnote(alloc, "1", fixture_self)) == null);
 }
 
-test "controls: resolveFootnote — no praxis join omits the spine clause" {
+test "controls: resolveFootnote — a configured join never adds a praxis clause" {
     const alloc = tst.allocator;
-    var cj = try controls.ControlJoin.init(
-        io,
-        alloc,
-        "src/test/controls_catalog.json",
-        null, // no TSC catalog
-        null, // no join configured
-        &.{"src/test/test_policy_controls.md"},
-    );
+    // Even with a praxis join loaded, the footnote body stays praxis-agnostic
+    // (#172/#174): spine membership lives on the web badges / annex / join.json,
+    // not inline in every footnote.
+    var cj = try fixtureControlJoin(alloc);
     defer cj.deinit();
 
-    const md = (try cj.resolveFootnote(alloc, "IAC-01")).?;
+    const md = (try cj.resolveFootnote(alloc, "IAC-01", null)).?;
     defer alloc.free(md);
-    try tst.expect(std.mem.indexOf(u8, md, "Identity & Access Management") != null);
-    try tst.expect(std.mem.indexOf(u8, md, "praxis:") == null);
-    try tst.expect(std.mem.indexOf(u8, md, "Covered by: Access Control Test Policy.") != null);
+    try tst.expect(std.mem.indexOf(u8, md, "praxis") == null);
+    try tst.expect(std.mem.indexOf(u8, md, "in control spine") == null);
 }
 
 test "controls: resolveFootnote — no catalog omits the title clause" {
@@ -1715,16 +1731,16 @@ test "controls: resolveFootnote — no catalog omits the title clause" {
         null, // no catalog
         null, // no TSC catalog
         "src/test/controls_join.json",
-        &.{"src/test/test_policy_controls.md"},
+        &.{ "src/test/test_policy_controls.md", "src/test/test_policy_controls_related.md" },
     );
     defer cj.deinit();
 
-    const md = (try cj.resolveFootnote(alloc, "IAC-01")).?;
+    const md = (try cj.resolveFootnote(alloc, "IAC-01", fixture_self)).?;
     defer alloc.free(md);
-    // Just the id (no "— title"), then the spine + covering clauses.
+    // Just the id (no "— title"), then the See-also clause for the other policy.
     try tst.expect(std.mem.startsWith(u8, md, "IAC-01."));
     try tst.expect(std.mem.indexOf(u8, md, "\u{2014}") == null);
-    try tst.expect(std.mem.indexOf(u8, md, "praxis: in control spine.") != null);
+    try tst.expect(std.mem.indexOf(u8, md, "See also: Access Control Standard.") != null);
 }
 
 test "controls: reviewControlRefs — clean fixture is none" {

--- a/src/test/test_policy_controls_related.md
+++ b/src/test/test_policy_controls_related.md
@@ -1,0 +1,22 @@
+---
+title: "Access Control Standard"
+description: "Second fixture policy: exercises 'See also' cross-references (another policy that also addresses IAC-01)"
+date: 2024-11-13
+weight: 20
+taxonomies:
+  SCF:
+    - IAC-01
+extra:
+  owner: SC2
+  last_reviewed: 2025-02-24
+  major_revisions:
+    - date: 2025-06-24
+      description: Initial version.
+      revised_by: Ada Byrne
+      approved_by: Ada Byrne
+      version: "1.0"
+---
+
+## Purpose
+
+Enterprise access control standard, also mapped to {{ control(id="IAC-01") }}.

--- a/templates/SCF/list.html
+++ b/templates/SCF/list.html
@@ -1,5 +1,6 @@
 {% extends "reports/base.html" %}
 {% import 'macros/coverage-bar.html' as macros_coverage %}
+{% import "partials/praxis/macros.html" as praxis %}
 
 {% block report_pdf %}
 {# Lock-step with src/control_report.zig Kind.pdfName (.scf). #}
@@ -16,15 +17,6 @@
 {% set tax = get_taxonomy(kind="SCF") %}
 {% set data = load_data(path=config.extra.policypress.scf_controls | default(value="data/scf.yml")) %}
 {% set line_items = tax.items | group_by(attribute="name") %}
-
-{# praxis control-join (optional): the committed list of SCF ids an external GRC
-   system actively governs. Guarded on the key being set so an unconfigured site
-   degrades — no spine bar, no per-control badges — with no load_data on an empty
-   path. `praxis.ids` is a flat array for cheap Tera membership tests. #}
-{% set praxis_path = config.extra.policypress.praxis_join | default(value="") %}
-{% set praxis = false %}
-{% if praxis_path %}{% set praxis = load_data(path=praxis_path, required=false) %}{% endif %}
-{% set has_praxis = praxis and praxis.ids %}
 
 {# Policy pages, for the out-of-scope third state below: a control with no
    covering policy may still be *deliberately* excluded by one. Fetched once;
@@ -45,16 +37,10 @@
 {% endfor %}
 {{ macros_coverage::coverage_bar(covered=covered_count, total=total_count, label="SCF Control Coverage") }}
 
-{# praxis spine coverage: of the ids in the control spine, how many have >=1
-   published policy mapped to them. Distinct from SCF coverage above (all catalog
-   controls) — this counts only the ids praxis actively governs. #}
-{% if has_praxis %}
-{% set_global spine_covered = 0 %}
-{% for sid in praxis.ids %}
-{% if sid in line_items %}{% set_global spine_covered = spine_covered + 1 %}{% endif %}
-{% endfor %}
-{{ macros_coverage::coverage_bar(covered=spine_covered, total=praxis.ids | length, label="praxis spine coverage") }}
-{% endif %}
+{# praxis overlay (optional, #174): the "praxis spine coverage" bar. Single
+   guarded hook — the partial self-guards on the join data and reuses
+   `line_items` from above. #}
+{% if config.extra.policypress.praxis_join %}{% include "partials/praxis/spine-bar.html" %}{% endif %}
 
 {% set domain_groups = data | group_by(attribute="domain") %}
 
@@ -103,9 +89,8 @@
             {{ control_policies | length }} {% if control_policies | length == 1 %}policy{% else %}policies{% endif %}
           </span>
           {% endif %}
-          {% if has_praxis and control.control_id in praxis.ids %}
-          <span class="praxis-badge" title="In praxis control spine">praxis</span>
-          {% endif %}
+          {# praxis overlay (optional, #174): per-control spine pill; empty when unconfigured. #}
+          {{ praxis::badge(config=config, id=control.control_id) }}
         </h3>
         {% if control.description %}<div class="control-description">{{ control.description }}</div>{% endif %}
       </div>

--- a/templates/partials/praxis/macros.html
+++ b/templates/partials/praxis/macros.html
@@ -1,0 +1,57 @@
+{#- ===========================================================================
+    praxis overlay — OPTIONAL, in-repo (issue #174)
+
+    Every praxis-specific rendering decision lives in this file (and its sibling
+    spine-bar.html), so the core SCF templates stay praxis-agnostic: a site with
+    no `praxis_join` configured renders exactly as if this overlay did not exist.
+
+    Each macro is SELF-GUARDING — it loads the join itself and degrades to empty
+    output when no join is set (Zola memoises load_data per build, so repeated
+    calls are cheap) — so core templates carry a single macro call at each
+    insertion point instead of scattered `{% if has_praxis %}` blocks or their
+    own `load_data`. `config` is passed in because Tera macros do not see the
+    global context.
+
+    Import once per template:
+        {% import "partials/praxis/macros.html" as praxis %}
+    =========================================================================== -#}
+
+{#- The flat list of SCF ids the praxis control spine governs, or [] when no
+    join is configured. Private helper the public macros build on; each loads it
+    itself rather than threading an array (Tera macros can only return strings). -#}
+
+{#- CSS class fragment (leading space) appended to a Framework-Coverage SCF tag
+    when `id` is in the praxis spine; empty otherwise. -#}
+{% macro tag_class(config, id) -%}
+{%- set path = config.extra.policypress.praxis_join | default(value="") -%}
+{%- if path %}{% set join = load_data(path=path, required=false) %}{%- if join and join.ids and id in join.ids %} satisfies-tag--praxis{% endif -%}{% endif -%}
+{%- endmacro tag_class %}
+
+{#- `title` attribute (leading space) for an in-spine Framework-Coverage SCF
+    tag; empty otherwise. -#}
+{% macro tag_title(config, id) -%}
+{%- set path = config.extra.policypress.praxis_join | default(value="") -%}
+{%- if path %}{% set join = load_data(path=path, required=false) %}{%- if join and join.ids and id in join.ids %} title="In praxis control spine"{% endif -%}{% endif -%}
+{%- endmacro tag_title %}
+
+{#- CSS class fragment (leading space) appended to an inline control reference
+    ({{ control(id="…") }}) when `id` is in the praxis spine; empty otherwise. -#}
+{% macro ref_class(config, id) -%}
+{%- set path = config.extra.policypress.praxis_join | default(value="") -%}
+{%- if path %}{% set join = load_data(path=path, required=false) %}{%- if join and join.ids and id in join.ids %} control-ref--praxis{% endif -%}{% endif -%}
+{%- endmacro ref_class %}
+
+{#- The spine-membership note for an inline control reference's tooltip
+    ("In praxis control spine"), or empty when `id` is not in the spine. The
+    caller composes it into the title with any control-name it already has. -#}
+{% macro spine_note(config, id) -%}
+{%- set path = config.extra.policypress.praxis_join | default(value="") -%}
+{%- if path %}{% set join = load_data(path=path, required=false) %}{%- if join and join.ids and id in join.ids %}In praxis control spine{% endif -%}{% endif -%}
+{%- endmacro spine_note %}
+
+{#- The per-control "praxis" pill for the SCF report table, or empty when `id`
+    is not in the spine. -#}
+{% macro badge(config, id) -%}
+{%- set path = config.extra.policypress.praxis_join | default(value="") -%}
+{%- if path %}{% set join = load_data(path=path, required=false) %}{%- if join and join.ids and id in join.ids %}<span class="praxis-badge" title="In praxis control spine">praxis</span>{% endif -%}{% endif -%}
+{%- endmacro badge %}

--- a/templates/partials/praxis/spine-bar.html
+++ b/templates/partials/praxis/spine-bar.html
@@ -1,0 +1,24 @@
+{#- praxis overlay (optional, #174): the "praxis spine coverage" bar for the SCF
+    report page.
+
+    Included by SCF/list.html behind the single praxis_join guard. Self-guarding
+    on the data too: renders nothing when the join is unset or empty. Reuses the
+    caller's `line_items` (SCF taxonomy terms that have >=1 mapped policy) to
+    count how many spine ids are covered — distinct from overall SCF coverage,
+    which spans the whole catalog. Keep the count logic identical to the pre-#174
+    inline block.
+
+    `macros_coverage` is imported by the includer (templates/SCF/list.html) —
+    Tera does not carry this partial's own import across an include inside an
+    inherited block, and list.html already imports it. -#}
+{%- set praxis_path = config.extra.policypress.praxis_join | default(value="") -%}
+{%- if praxis_path -%}
+{%- set praxis = load_data(path=praxis_path, required=false) -%}
+{%- if praxis and praxis.ids -%}
+{%- set_global spine_covered = 0 -%}
+{%- for sid in praxis.ids -%}
+{%- if sid in line_items -%}{%- set_global spine_covered = spine_covered + 1 -%}{%- endif -%}
+{%- endfor -%}
+{{ macros_coverage::coverage_bar(covered=spine_covered, total=praxis.ids | length, label="praxis spine coverage") }}
+{%- endif -%}
+{%- endif -%}

--- a/templates/partials/satisfies.html
+++ b/templates/partials/satisfies.html
@@ -1,14 +1,15 @@
+{#- Framework Coverage card list for a policy page. Core SCF rendering is
+    praxis-agnostic; the optional praxis spine marker on an SCF tag comes from
+    the praxis overlay macros (partials/praxis/macros.html), invoked as the
+    `praxis` namespace. That namespace is imported by the includer
+    (templates/policies/page.html) — Tera does not carry a partial's own imports
+    across an include inside an inherited block, so it must be imported there.
+    Remove that import and the two `praxis::` calls below and this template is
+    fully praxis-free. -#}
 {% set page_tax = page.taxonomies %}
 {% if page_tax %}
 {%- set pp = config.extra.policypress -%}
 {%- set scf_report = pp.scf_report_page | default(value="") -%}
-{#- praxis spine ids, guarded on the key being set (degrades when unconfigured). -#}
-{%- set praxis_ids = [] -%}
-{%- set praxis_path = pp.praxis_join | default(value="") -%}
-{%- if praxis_path -%}
-{%- set praxis = load_data(path=praxis_path, required=false) -%}
-{%- if praxis and praxis.ids -%}{%- set praxis_ids = praxis.ids -%}{%- endif -%}
-{%- endif -%}
 <div class="satisfies">
   <span class="satisfies-label">Framework Coverage</span>
   <div class="satisfies-cards">
@@ -18,10 +19,7 @@
       <div class="satisfies-tags">
         {% for term in terms %}
         {%- if key == "SCF" and scf_report -%}
-        {%- set tag_class = "satisfies-tag" -%}
-        {%- set in_spine = term in praxis_ids -%}
-        {%- if in_spine -%}{%- set tag_class = tag_class ~ " satisfies-tag--praxis" -%}{%- endif -%}
-        <a class="{{ tag_class }}" href="{{ get_url(path=scf_report) | safe }}#{{ term }}"{% if in_spine %} title="In praxis control spine"{% endif %}>{{ term }}</a>
+        <a class="satisfies-tag{{ praxis::tag_class(config=config, id=term) }}" href="{{ get_url(path=scf_report) | safe }}#{{ term }}"{{ praxis::tag_title(config=config, id=term) }}>{{ term }}</a>
         {%- else -%}
         <span class="satisfies-tag">{{ term }}</span>
         {%- endif -%}

--- a/templates/policies/page.html
+++ b/templates/policies/page.html
@@ -1,5 +1,6 @@
 {% extends "page.html" %}
 {% import 'macros/policies-latest-revision.html' as macros_policies -%}
+{% import "partials/praxis/macros.html" as praxis -%}
 
 {% block body %}
 {% set page_class = "docs single" %}

--- a/templates/shortcodes/control.html
+++ b/templates/shortcodes/control.html
@@ -1,14 +1,19 @@
 {#- Inline control reference: {{ control(id="IAC-01") }}
 
     Renders a link to the SCF report page anchor for `id`, titled with the
-    control's name from the SCF catalog. When the praxis join is configured and
-    the id is in the control spine, adds the `control-ref--praxis` marker.
+    control's name from the SCF catalog.
 
     Degrades to a styled <span> when `scf_report_page` is unset (the starter
     case): the reference still reads as a control id, it just isn't linkable
     because there is no report page to anchor into. The PDF pipeline rewrites the
     shortcode independently (src/utils.zig replace_control_refs), so this template
-    only governs the website. -#}
+    only governs the website.
+
+    Core rendering is praxis-agnostic. The optional praxis spine decoration (an
+    extra class + a tooltip note) comes from the praxis overlay macros
+    (partials/praxis/macros.html); remove the import and the two macro-fed lines
+    below and the reference is fully praxis-free. -#}
+{%- import "partials/praxis/macros.html" as praxis -%}
 {%- set pp = config.extra.policypress -%}
 {%- set report_page = pp.scf_report_page | default(value="") -%}
 
@@ -23,19 +28,14 @@
 {%- if match and match.control -%}{%- set ctrl_title = match.control | trim -%}{%- endif -%}
 {%- endif -%}
 
-{#- praxis spine membership — guarded on the key being set so an unconfigured
-    site (starter) never triggers a load_data on an empty path. -#}
-{%- set in_spine = false -%}
-{%- set praxis_path = pp.praxis_join | default(value="") -%}
-{%- if praxis_path -%}
-{%- set praxis = load_data(path=praxis_path, required=false) -%}
-{%- if praxis and praxis.ids and id in praxis.ids -%}{%- set in_spine = true -%}{%- endif -%}
-{%- endif -%}
+{#- praxis overlay hook (optional, #174): the class fragment and spine note both
+    come from the overlay macros (empty when no join is configured). Captured
+    into vars first — Tera rejects a namespaced macro call as an operand of `~`. -#}
+{%- set praxis_class = praxis::ref_class(config=config, id=id) -%}
+{%- set classes = "control-ref" ~ praxis_class -%}
+{%- set spine_note = praxis::spine_note(config=config, id=id) | trim -%}
 
-{%- set classes = "control-ref" -%}
-{%- if in_spine -%}{%- set classes = classes ~ " control-ref--praxis" -%}{%- endif -%}
-
-{#- Compose the title attribute value (name and/or spine note). -#}
+{#- Compose the title attribute value (control name and/or spine note). -#}
 {%- set tip = ctrl_title -%}
-{%- if in_spine -%}{%- if tip -%}{%- set tip = tip ~ " · In praxis control spine" -%}{%- else -%}{%- set tip = "In praxis control spine" -%}{%- endif -%}{%- endif -%}
+{%- if spine_note -%}{%- if tip -%}{%- set tip = tip ~ " · " ~ spine_note -%}{%- else -%}{%- set tip = spine_note -%}{%- endif -%}{%- endif -%}
 {%- if report_page -%}<a class="{{ classes }}" href="{{ get_url(path=report_page) | safe }}#{{ id }}"{% if tip %} title="{{ tip }}"{% endif %}>{{ id }}</a>{%- else -%}<span class="{{ classes }}"{% if tip %} title="{{ tip }}"{% endif %}>{{ id }}</span>{%- endif -%}

--- a/tests/golden/test_policy_controls.typ
+++ b/tests/golden/test_policy_controls.typ
@@ -95,10 +95,10 @@
 )
 
 == Purpose
-Access is least-privilege #footnote[IAC-01 — Identity & Access Management. praxis: in control spine. Covered by: Access Control Test Policy.] enforced across all systems.
+Access is least-privilege #footnote[IAC-01 — Identity & Access Management. See also: Access Control Standard.] enforced across all systems.
 
 == Data protection
-All data is classified and protected #footnote[DCH-01 — Data Protection. praxis: not in control spine. Covered by: Access Control Test Policy.] according to its sensitivity.
+All data is classified and protected #footnote[DCH-01 — Data Protection.] according to its sensitivity.
 
 
 #pagebreak()


### PR DESCRIPTION
Folds #172 into #174. praxis is an **optional overlay**, not part of core PolicyPress; this un-weaves it from the core SCF surfaces and reframes the control footnote to be praxis-free. A site with no `praxis_join` configured now renders as if the overlay did not exist.

## Overlay boundary (#174)

All praxis rendering moved into a dedicated, removable set:

- `templates/partials/praxis/macros.html` — self-guarding macros (`tag_class`, `tag_title`, `ref_class`, `spine_note`, `badge`), each loads the join itself and emits nothing when unconfigured.
- `templates/partials/praxis/spine-bar.html` — the "praxis spine coverage" bar.
- `sass/components/_praxis.scss` — the praxis styles (`.satisfies-tag--praxis`, `.control-ref--praxis`, `.praxis-badge`), imported behind the overlay boundary in `main.scss`.

Core SCF templates now carry a single praxis macro call / guarded include per insertion point instead of inline `load_data` + scattered `has_praxis` blocks:

- `templates/partials/satisfies.html` — SCF tag gets `praxis::tag_class` / `praxis::tag_title`.
- `templates/SCF/list.html` — `praxis::badge` per control; a single guarded `{% include "partials/praxis/spine-bar.html" %}` for the bar.
- `templates/shortcodes/control.html` — `praxis::ref_class` + `praxis::spine_note`.

The `praxis` namespace is imported in the rendered `templates/policies/page.html` (not in `satisfies.html`) because Tera does not carry a partial's own imports across an `include` inside an inherited block.

**Zig:** the footnote resolver is praxis-agnostic; the one residual praxis touch in `ControlJoin` (a load-time catalog-skew diagnostic) is quarantined behind the clearly-named `checkPraxisCatalogSkew` seam. `src/control_report.zig`, `audit/join.json`, and the PDF coverage annex were already praxis-free and are untouched.

## Footnote change (#172)

Before: `IAC-01 — Identity & Access Management (IAM). praxis: in control spine. Covered by: Example Security Policy.`
After:  `IAC-01 — Identity & Access Management (IAM). See also: Acceptable Use Policy.`

- The praxis clause is dropped (spine membership still lives on web badges, the annex, and `audit/join.json`).
- "Covered by" → "See also", listing only the **other** policies addressing the control (the owning policy is excluded); the clause is omitted entirely when no other policy covers it (e.g. `CRY-01 — Use of Cryptographic Controls.`).

Because `zigmark.footnotes.Resolver` was a single shared instance, "self" could not be excluded. The resolver is now built **per document**: each concurrent `compileOne` task constructs a stack-local `controls.DocResolver` bound to that policy's path — no shared mutable resolver. `coveringPolicies` gained an exclude-by-path parameter.

## No-praxis-when-unconfigured invariant

New flake check **`praxis-optional`** builds the demo web output with `praxis_join` commented out and fails if any praxis-overlay markup (`praxis-badge`, `satisfies-tag--praxis`, `control-ref--praxis`, `In praxis control spine`, `praxis spine coverage`) appears in `public/`. Verified locally: zero overlay tokens without a join; identical badges/bar/markers with a join.

## Tests

- `test_policy_controls` golden loses the praxis clause and uses "See also" (excluding the fixture's own policy). A second fixture policy (`src/test/test_policy_controls_related.md`) gives `IAC-01` another covering policy so the golden shows both the listed case (`See also: Access Control Standard.`) and the omitted case (`DCH-01 — Data Protection.`).
- `controls` resolver unit tests updated for the praxis-free "See also" body (per-document exclusion, sorted multi-policy list, omission).
- `zig build test`, `nix build .#checks.x86_64-linux.{zola-check,praxis-optional,test,formatting}`, and `zig fmt --check` all pass. Demo PDFs compile; footnotes show "See also" with self excluded and no `praxis:` clause.

Closes #174
Closes #172
Refs #127
