### PR TITLE
fix: segfault on top-level --version/--help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,16 @@ versioning; breaking changes to it bump the major version.
   all. Also removed a never-included `contributors.html` partial, an empty
   leftover `templates/pdf/policy.tex`, and a dead debug comment in
   `src/control_report.zig`.
+- `policypress --version` and `policypress --help` no longer segfault. The
+  top-level flag path is now handled directly — printing the version and the
+  top-level usage respectively and exiting 0 — instead of falling through to the
+  build path (which knew nothing about `--version`). The underlying crash was a
+  `std.Io.Writer` migration bug: `runBuild` took the `.interface` field off the
+  temporary `File.Writer` returned by `stderr().writer(...)`, so once that
+  temporary went out of scope the flush/drain vtable recovered a dangling parent
+  via `@fieldParentPtr` and dereferenced a stale file handle. The writer is now
+  kept in a named local (matching `stage-site`), which also fixes `build --help`
+  and clap error reporting.
 
 ## [1.6.1] - 2026-07-21
 

--- a/build.zig
+++ b/build.zig
@@ -273,6 +273,24 @@ pub fn build(b: *std.Build) !void {
         const run_golden_tests = b.addRunArtifact(golden_tests);
         run_golden_tests.setCwd(b.path("."));
         test_step.dependOn(&run_golden_tests.step);
+
+        // Regression guard for the top-level `--version` / `--help` paths, which
+        // segfaulted when runBuild built its stderr writer by taking `.interface`
+        // off a temporary File.Writer (the parent struct went out of scope, so
+        // the flush vtable dereferenced a dangling file handle). Runs the real
+        // binary and asserts a clean exit with the expected output; neither path
+        // reads config or touches the filesystem, so it is sandbox-safe.
+        const cli_version = b.addRunArtifact(policypress_exe);
+        cli_version.addArg("--version");
+        cli_version.expectExitCode(0);
+        cli_version.expectStdErrMatch(zon.version);
+        test_step.dependOn(&cli_version.step);
+
+        const cli_help = b.addRunArtifact(policypress_exe);
+        cli_help.addArg("--help");
+        cli_help.expectExitCode(0);
+        cli_help.expectStdErrMatch("Usage: policypress");
+        test_step.dependOn(&cli_help.step);
     }
     {
         // Fuzz harness for PolicyPress's own surfaces (src/fuzz.zig).

--- a/src/main.zig
+++ b/src/main.zig
@@ -138,6 +138,22 @@ pub fn main(init: std.process.Init) void {
     // argv[0] is the binary name; user arguments start at argv[1].
     const user_args: []const [:0]const u8 = if (argv.len > 1) argv[1..] else &.{};
 
+    // Top-level informational flags (no subcommand). Handled here with
+    // std.debug.print — like the `help` subcommand below — so they never fall
+    // through to the build path, which knows nothing about `--version`.
+    // Subcommand-specific help (e.g. `build --help`) is handled per-subcommand.
+    if (user_args.len > 0) {
+        const first = user_args[0];
+        if (std.mem.eql(u8, first, "--version") or std.mem.eql(u8, first, "-V")) {
+            std.debug.print("policypress {s}\n", .{build_options.version});
+            return;
+        }
+        if (std.mem.eql(u8, first, "--help") or std.mem.eql(u8, first, "-h")) {
+            std.debug.print("{s}", .{top_level_usage});
+            return;
+        }
+    }
+
     // If the first user argument looks like a subcommand (no leading '-'), dispatch.
     if (user_args.len > 0 and !std.mem.startsWith(u8, user_args[0], "-")) {
         const subcmd = user_args[0];
@@ -246,7 +262,14 @@ fn runBuild(io: std.Io, env: *EnvMap, alloc: Allocator, args: []const [:0]const 
         \\    --json             Emit log output as JSON lines (for CI).
     );
     var buf: [128]u8 = undefined;
-    var stderr = std.Io.File.stderr().writer(io, &buf).interface;
+    // Keep the File.Writer in a named local: `&w.interface` must point *into*
+    // the live struct so the flush/drain vtable can recover it via
+    // @fieldParentPtr. Taking `.interface` off the temporary returned by
+    // writer() left the parent File.Writer dangling, so flushing a non-empty
+    // buffer (a clap error or `--help` output) dereferenced a bad file handle
+    // and segfaulted.
+    var stderr_writer = std.Io.File.stderr().writer(io, &buf);
+    const stderr = &stderr_writer.interface;
     defer stderr.flush() catch {};
     var diag = clap.Diagnostic{};
 
@@ -260,14 +283,14 @@ fn runBuild(io: std.Io, env: *EnvMap, alloc: Allocator, args: []const [:0]const 
         .diagnostic = &diag,
         .allocator = alloc,
     }) catch |err| {
-        diag.report(&stderr, err) catch {};
+        diag.report(stderr, err) catch {};
         return err;
     };
     defer res.deinit();
 
     if (res.args.help != 0) {
         std.debug.print("PolicyPress\n\n", .{});
-        return clap.help(&stderr, clap.Help, &params, .{});
+        return clap.help(stderr, clap.Help, &params, .{});
     }
 
     // --- Load config ---


### PR DESCRIPTION
## Why

QA found `policypress --version` and `policypress --help` both **segfault** (SIGABRT, exit 134) — a new user's first instinct to check their install crashes with a core dump. The GitHub Action never hits these flags, so CI stayed green, but it's a poor first impression and means you can't verify which version built an artifact.

## Root cause

Two issues on the top-level flag path:

1. **`std.Io.Writer` lifetime bug.** `runBuild` built its stderr writer as `std.Io.File.stderr().writer(io, &buf).interface`, copying the `.interface` field *out of* the temporary `File.Writer`. Once that temporary went out of scope, the flush/drain vtable recovered a dangling parent via `@fieldParentPtr` and dereferenced a stale file handle — crashing whenever a non-empty buffer was actually flushed (a clap error, `build --help`). Plain builds buffered nothing, which is why they worked.
2. **No `--version` handler.** `--version` fell through to the build path, where clap rejected it as unknown, buffered the error, and the `defer flush()` then segfaulted.

## Fix

- Keep the `File.Writer` in a named local (`var stderr_writer = …; const stderr = &stderr_writer.interface;`) so `&…interface` points into the live struct — the same idiom `stage-site`'s `printLine` already uses. Also fixes `build --help` and clap error reporting.
- Route top-level `--version`/`-V` and `--help`/`-h` through a dedicated handler (`std.debug.print`, like the existing `help` subcommand) that prints and exits 0.

## Test

Regression guard on `zig build test`: runs the real binary with `--version` and `--help`, asserting exit 0 and the expected output. Sandbox-safe (neither reads config or the filesystem). Fails loudly if the segfault returns.

## Verification (real output)

ReleaseSafe nix binary:
- `--version` / `-V` → `policypress 1.6.1`, exit 0
- `--help` / `-h` → `Usage: policypress [SUBCOMMAND] [OPTIONS]`, exit 0
- `--badflag` → `Invalid argument '--badflag'` via the fixed writer, exit 1 (no crash)

`zig build test` → **110/110 tests passed** (incl. the two new smoke tests).

## Base branch

Targets `chore/licensing` for a clean diff. Note: the CHANGELOG entry lands in the same `[Unreleased] → Fixed` spot as #184, so expect a trivial keep-both conflict if both merge.