### PR TITLE
docs: sharpen the GitHub Marketplace listing (tagline + license clarity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ versioning; breaking changes to it bump the major version.
 
 ## [Unreleased]
 
+### Changed
+
+- Marketplace listing polish: a clearer Action tagline (`action.yml` description)
+  and a README banner that makes the "free for your own organization; commercial
+  license only to serve others" split unmissable above the fold (the GitHub
+  Marketplace listing renders the README).
+
 ## [1.7.0] - 2026-07-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Compliance policy management for small and mid-size teams — write policies in 
 
 PolicyPress is built on [Zola](https://www.getzola.org/) and [Typst](https://typst.app/). You host it yourself in your own Git repository — PolicyPress is the theme and toolchain, not the content, so your policies never leave your infrastructure. Organizations that run several instances — a nonprofit with multiple programs, or a small business with a few brands or entities — keep one shared toolchain and a separate, owned policy repository per entity.
 
+> **Free to run for your own organization**, at any size — no subscription. A commercial license is required only to offer PolicyPress *to others* (an MSP running it for clients, a hosted/SaaS offering, or redistribution). See [Licensing](#license).
+
 ## See it in action
 
 [![PolicyPress homepage showing the hero and feature overview](docs/media/homepage.png)](https://policypress.sc2.in)

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: PolicyPress
-description: Compliance policy management — write policies in Markdown, publish a branded policy site and audit-ready PDFs.
+description: Compliance policy management - write policies in Markdown, publish a branded policy site and audit-ready PDFs.
 author: sc2in
 
 branding:

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: PolicyPress
-description: Build ISMS policy PDFs and a Zola static site from markdown content.
+description: Compliance policy management — write policies in Markdown, publish a branded policy site and audit-ready PDFs.
 author: sc2in
 
 branding:


### PR DESCRIPTION
Prep for the GitHub Marketplace publish (which we're treating as the v2 launch). The Marketplace listing renders `action.yml`'s `description` as the tagline and the repo README as the body, so both should read well cold and make the licensing model obvious.

## Changes
- **`action.yml` tagline** — replace *"Build ISMS policy PDFs and a Zola static site from markdown content"* (jargon: "ISMS") with a plain one-liner: *"Compliance policy management — write policies in Markdown, publish a branded policy site and audit-ready PDFs."*
- **README license banner** — a one-line callout above the fold: free to run for your own organization at any size, commercial license only to offer it *to others* (MSP/hosted/redistribution). The Marketplace is exactly where MSPs/resellers land, so the free-vs-paid split shouldn't require scrolling to the License section.
- CHANGELOG note under `[Unreleased]`.

Docs-only; no code, no behavior change.

## Marketplace readiness (already verified)
`action.yml` is at repo root (single action), `branding` icon `shield` + color `blue` are both in GitHub's allowed sets, the listing name "PolicyPress" is unique (0 existing results), and the repo is public with README + LICENSE. Remaining publish steps are manual in the release UI (tick "Publish to Marketplace", accept the Developer Agreement, pick a category) and require 2FA on the org.