### PR TITLE
fix: warn loudly on unquoted revision versions

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -413,9 +413,46 @@ pub const Config = struct {
             },
         };
         return maxKind(
-            maxKind(reviewPolicyBody(alloc, path, content), self.reviewOverdue(path, frontMatter)),
-            self.reviewHeadings(alloc, path, content),
+            maxKind(
+                maxKind(reviewPolicyBody(alloc, path, content), self.reviewOverdue(path, frontMatter)),
+                self.reviewHeadings(alloc, path, content),
+            ),
+            reviewRevisionVersions(path, frontMatter),
         );
+    }
+
+    /// Flag revision `version` values written *unquoted* in the YAML front
+    /// matter. zigmark's parser reads an unquoted `version: 1.0` as a number,
+    /// and the PDF/filename then renders it losslessly-wrong: `1.0` becomes
+    /// "1" and `1.10` becomes "1.1" (trailing/omitted decimals vanish). Because
+    /// the version string is the spine of the audit trail, a silently-mangled
+    /// version is an integrity failure — critical, same class as raw HTML that
+    /// diverges site-vs-PDF. The original text cannot be recovered from the
+    /// parsed number, so the only fix is to tell the author to quote it.
+    fn reviewRevisionVersions(path: []const u8, frontMatter: zigmark.Frontmatter) IssueKind {
+        const revs = frontMatter.get("extra.major_revisions") orelse return .none;
+        switch (revs) {
+            .array => |arr| {
+                var worst: IssueKind = .none;
+                for (arr.items) |rev| {
+                    const version = rev.object.get("version") orelse continue;
+                    switch (version) {
+                        .float, .integer => {
+                            conflog.warn(
+                                "{s}: revision version is unquoted, so YAML read it as a number; the PDF will " ++
+                                    "show a mangled version (e.g. 1.0 -> \"1\", 1.10 -> \"1.1\"). Quote it as a " ++
+                                    "string, e.g. version: \"1.0\".",
+                                .{path},
+                            );
+                            worst = .critical;
+                        },
+                        else => {},
+                    }
+                }
+                return worst;
+            },
+            else => return .none,
+        }
     }
 
     /// Check the Markdown body for constructs that silently diverge between the

--- a/src/test.zig
+++ b/src/test.zig
@@ -275,6 +275,25 @@ test "review preflight flags overdue policies" {
     );
 }
 
+test "review preflight flags unquoted revision versions" {
+    const alloc = tst.allocator;
+    var conf = try config.load(io, alloc, TestConfig);
+    defer conf.deinit(alloc);
+    // Pin the date so the recent last_reviewed is never the reason for a flag.
+    conf.date = .{ .year = 2026, .month = 1, .day = 1 };
+    // unquoted_version.md: `version: 1.0` (no quotes) -> YAML reads it as a
+    // number and the rendered version would silently mangle -> audit-critical.
+    try tst.expectEqual(
+        config.IssueKind.critical,
+        conf.reviewPolicyFile(io, alloc, "src/test/unquoted_version.md"),
+    );
+    // fresh_policy.md is identical but quotes the version -> clean.
+    try tst.expectEqual(
+        config.IssueKind.none,
+        conf.reviewPolicyFile(io, alloc, "src/test/fresh_policy.md"),
+    );
+}
+
 test "ua-1 preflight flags heading-level skips only when pdf_standard is set" {
     const alloc = tst.allocator;
     var conf = try config.load(io, alloc, TestConfig);

--- a/src/test/unquoted_version.md
+++ b/src/test/unquoted_version.md
@@ -1,0 +1,19 @@
+---
+title: "Unquoted Version Policy"
+description: "A policy whose revision version was written unquoted, for testing the preflight."
+date: 2025-12-15
+weight: 10
+extra:
+  owner: SC2
+  last_reviewed: 2025-12-15
+  major_revisions:
+    - date: 2025-12-15
+      description: Initial version.
+      revised_by: Ada Byrne
+      approved_by: Ada Byrne
+      version: 1.0
+---
+
+## Introduction
+
+This policy's version is unquoted, so YAML reads it as the number 1.0.


### PR DESCRIPTION
## What

An unquoted `version: 1.0` in a policy's front matter is read by the YAML parser as a **number**, and the rendered version then silently mangles: `1.0` becomes `"1"` and `1.10` becomes `"1.1"` — in both the PDF and its filename. Since the version string is the spine of the audit trail, a silently-corrupted version is an integrity failure that ships by default.

Found while pressure-testing the non-technical authoring path: an editor who types a version without quotes gets a wrong version number on the audit artifact with no warning.

## Fix

The original text is unrecoverable from the parsed number, so this adds a preflight check (`reviewRevisionVersions`) that warns when a revision `version` was written unquoted — naming the file and telling the author to quote it. It's classed audit-critical (so `--strict` also catches it), but the **default build still completes**: a non-technical editor sees an actionable warning on the next push rather than a red build.

## Behavior

```
encryption.md: revision version is unquoted, so YAML read it as a number;
the PDF will show a mangled version (e.g. 1.0 -> "1", 1.10 -> "1.1").
Quote it as a string, e.g. version: "1.0".
```

Verified against fixtures: `version: 1.0` warns and still builds; `version: "1.0"` is clean.

## Tests

Adds a regression test and fixture (`src/test/unquoted_version.md`), mirrored on the existing `fresh_policy.md` so the version is the only variable. `zig build test` green; `zig fmt --check` clean.