### PR TITLE
fix: separate consecutive footnote references (#189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ versioning; breaking changes to it bump the major version.
 
 ## [Unreleased]
 
+### Fixed
+
+- Consecutive footnote references are now readable. Markdown allows adjacent
+  footnote markers, and a control plus its sub-controls is the common case on a
+  `control_footnotes` site — but the theme styled only `.footnote-definition`, so
+  `[^GOV-19][^GOV-19.1][^GOV-19.2]` rendered as "192021", a single 6-digit number
+  rather than three citations. Adjacent markers are now comma-separated
+  ("19,20,21"). The demo policy gained an adjacent-reference run so the a11y scan
+  covers the path (#189).
+- The footnote-definition marker sat on the baseline instead of raised: its
+  `top` was `-0.2.5em`, which has two decimal points, so browsers dropped the
+  whole declaration (#189).
+
 ## [1.7.1] - 2026-07-25
 
 ### Fixed

--- a/content/policies/example-security-policy.md
+++ b/content/policies/example-security-policy.md
@@ -156,7 +156,7 @@ All personnel must complete security awareness training:
 
 ### All Personnel
 
-- Follow security policies and procedures
+- Follow security policies and procedures [^HRS-05][^HRS-05.1][^HRS-05.3]
 - Report security incidents promptly
 - Complete required security training
 - Protect credentials and access tokens

--- a/sass/components/_footnote.scss
+++ b/sass/components/_footnote.scss
@@ -1,6 +1,22 @@
+// Inline markers, e.g. the "[^IAC-01]" citations in a policy statement. Markdown
+// allows adjacent footnote references, and a control plus its sub-controls is the
+// common case on a `control_footnotes` site — but with no rule here the <sup>
+// elements sit flush and "[^GOV-19][^GOV-19.1][^GOV-19.2]" renders as "192021",
+// one 6-digit number rather than three citations. Separate adjacent markers with
+// a comma to get "19,20,21" (#189).
+//
+// The ::before is inside the <sup>, so it already inherits that element's raise
+// and reduced size; giving it its own vertical-align/font-size would double-apply
+// both and lift the comma clear of the digits it separates.
+.footnote-reference + .footnote-reference::before {
+  content: ",";
+}
+
 .footnote-definition {
   sup {
-    top: -0.2.5em;
+    // Was "-0.2.5em" — two decimal points, so browsers dropped the whole
+    // declaration and the marker sat on the baseline (#189).
+    top: -0.25em;
     font-size: 0.75em;
     display: inline;
   }


### PR DESCRIPTION
Closes #189.

## Problem

Markdown allows adjacent footnote references, and a parent control plus its sub-controls is the common case on a `control_footnotes` site. The theme styled only `.footnote-definition` — there was no rule for the inline `.footnote-reference` markers anywhere in `sass/`, `templates/`, or `src/` — so consecutive `<sup>` elements sat flush against each other:

```
[^GOV-18][^GOV-19][^GOV-19.1][^GOV-19.2]   →   "15161718"
```

Four citations reading as one 8-digit number. Reported from SC2's internal portal.

The same file also had `top: -0.2.5em` on `.footnote-definition sup` — two decimal points, so browsers dropped the whole declaration and the definition marker sat on the baseline rather than raised.

## Change

- `.footnote-reference + .footnote-reference::before { content: "," }` — separates adjacent markers only, leaving a lone reference untouched. Renders "2,3,4".
- `top: -0.25em` — the intended value, so the declaration now survives parsing.
- The demo policy's **All Personnel** statement gains an `HRS-05` parent plus two sub-controls. Demo content had *no* adjacent references, which is why this shipped unnoticed; this puts the path under the axe-core scan that already covers `/policies/example-security-policy/`.

The `::before` sits inside the `<sup>` and inherits its raise and reduced size, so it deliberately sets neither `vertical-align` nor `font-size`. The issue's suggested snippet included both; applying them double-raises the comma clear of the digits it separates. It also lands outside the `<a>`, so the separator is not part of the link text.

Scoped to CSS — no range-collapsing (`15–18`) in `src/stage.zig`, which would touch footnote synthesis and the golden tests.

## Verification

- `nix run .#a11y-scan` — PASS, 0 violation types across 10 pages × 2 modes (light + dark).
- `nix build .#checks.x86_64-linux.redaction-leak` — passes; it asserts on this policy's `[^IAC-01]` staging and is unaffected (its `^\[\^IAC-01\]: ` greps don't match the new `.1`/`.3` definition lines).
- `nix build .#checks.x86_64-linux.formatting` — passes.
- Compiled output confirmed: `.footnote-reference+.footnote-reference::before{content:","}` and `.footnote-definition sup{top:-.25em;...}`.
- Full pipeline run (`stage-site` → `zola build`) emits three flush `<sup class="footnote-reference">` markers on the new statement, and a headless Chromium render shows "2,3,4" at the correct superscript height.