### PR TITLE
chore: harden the action for Marketplace consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ versioning; breaking changes to it bump the major version.
 
 ## [Unreleased]
 
+### Fixed
+
+- The Action now fails fast on a Windows runner, naming the reason and pointing
+  at the installation guide, instead of getting as far as installing Nix before
+  dying on an unrelated-looking error. Nothing stated the requirement anywhere:
+  the toolchain builds on Nix, which has no Windows support, and release binaries
+  ship for Linux and macOS only. `action.yml`, the README, and the installation
+  guide now all say so, and the binary resolver's bare "Unsupported platform"
+  names the supported set.
+- Inline `code` inside an admonition now meets WCAG AA. Bootstrap's
+  `--bs-code-color` (`#d63384`) measures 4.50:1 on white — AA by a hair, with no
+  headroom — so over an admonition's background tint it fell to 4.26:1. It is now
+  blended toward the body colour (the technique `.admonition-title` already used
+  for the same reason), reaching ~6.3:1 on every admonition type while keeping the
+  hue. Caught by the axe-core gate when the guide above added a code span to a
+  callout; dark mode was already compliant via its own rule.
+
+### Security
+
+- SHA-pinned `actions/checkout` inside `action.yml` (to `v4.4.0`, the revision
+  already used throughout `.github/workflows`). It was the one floating `uses:`
+  ref left in the action, and unlike the workflow refs it runs inside every
+  consumer's pipeline, so an upstream tag move would have changed what every
+  PolicyPress user executes. Completes the pinning work from #157.
+
 ## [1.7.1] - 2026-07-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Self-hosted, Git-native, and **free to run for your own organization** — any c
 2. On every push, the `sc2in/policypress` GitHub Action builds the policy site and generates PDFs
 3. The site deploys to GitHub Pages; PDFs are uploaded as artifacts for download
 
+The Action needs a **Linux or macOS runner** — `runs-on: ubuntu-latest` is the recommended choice and what every example here uses. Windows runners are not supported (the toolchain builds on Nix, and release binaries ship for Linux and macOS on x86_64 and aarch64). This is about the runner only; you can author policies from any OS, Windows included.
+
 ## Quick start
 
 **The fastest path:** use the [policypress-template](https://github.com/sc2in/policypress-template) repository. Click **Use this template → Create a new repository**, edit `config.toml` with your organization name and brand color, replace the logo, enable GitHub Pages, and push.

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,8 @@
+# Requires a Linux or macOS runner (`runs-on: ubuntu-latest` is recommended).
+# Windows runners are not supported: the action builds on Nix, which has no
+# Windows support, and release binaries are published for Linux and macOS only.
 name: PolicyPress
-description: Compliance policy management - write policies in Markdown, publish a branded policy site and audit-ready PDFs.
+description: Compliance policy management on Linux/macOS runners - write policies in Markdown, publish a branded policy site and audit-ready PDFs.
 author: sc2in
 
 branding:
@@ -74,6 +77,21 @@ outputs:
 runs:
   using: composite
   steps:
+    # Fail fast, and say why. The action runs on Nix, which has no Windows
+    # support, and ships release binaries for Linux and macOS only — so on a
+    # windows-latest runner every path here is a dead end. Without this guard the
+    # run got as far as installing Nix before dying on an unrelated-looking
+    # error, or reached the binary resolver's bare "Unsupported platform".
+    - name: Check runner platform
+      shell: bash
+      run: |
+        if [ "${RUNNER_OS}" = "Windows" ]; then
+          echo "::error::PolicyPress does not support Windows runners." \
+               "Use runs-on: ubuntu-latest (recommended) or a macOS runner." \
+               "See https://policypress.sc2.in/guides/installation/"
+          exit 1
+        fi
+
     - name: Install Nix
       uses: DeterminateSystems/determinate-nix-action@c70cb8ae92d68c66953db28a26a63db1665bc837 # v3
       with:
@@ -110,7 +128,10 @@ runs:
         esac
 
     - name: Fetch policypress theme
-      uses: actions/checkout@v4
+      # SHA-pinned like every other `uses:` here and in .github/workflows (#157).
+      # This one runs in the consumer's workflow, so a floating tag would let an
+      # upstream tag move change what every PolicyPress user executes.
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         repository: sc2in/policypress
         # The pinned ref (v1, v1.7.0, …) resolved from the action path above; empty
@@ -149,7 +170,9 @@ runs:
             Darwin-arm64)   BINARY="policypress-aarch64-macos" ;;
             Darwin-x86_64)  BINARY="policypress-x86_64-macos" ;;
             *)
-              echo "Unsupported platform: $(uname -s)-$(uname -m)"
+              echo "::error::Unsupported platform: $(uname -s)-$(uname -m)." \
+                   "PolicyPress ships binaries for Linux and macOS on x86_64 and" \
+                   "aarch64. Use runs-on: ubuntu-latest (recommended)."
               exit 1
               ;;
           esac

--- a/content/guides/installation.md
+++ b/content/guides/installation.md
@@ -70,6 +70,11 @@ Your pipeline's checkout step must initialize the submodule. The ADO example bel
 
 ### Pipeline
 
+{% admonition(type="note", title="Runner requirements") %}
+<p>PolicyPress builds on a <strong>Linux or macOS</strong> agent - <code>ubuntu-latest</code> is recommended and is what every example below uses. Release binaries ship for Linux and macOS on x86_64 and aarch64.</p>
+<p><strong>Windows agents are not supported</strong>, because the toolchain builds on Nix. The Action fails fast and names the reason rather than dying part-way through a build. Authoring is unaffected - you can write policies on Windows. It is only the CI agent that must be Linux or macOS.</p>
+{% end %}
+
 <div class="tab-group" data-default="GitHub Actions">
 <div class="tab-pane" data-tab="GitHub Actions">
 

--- a/sass/components/_alerts.scss
+++ b/sass/components/_alerts.scss
@@ -109,6 +109,16 @@
     > *:last-child {
       margin-bottom: 0;
     }
+
+    // Inline code needs its own colour here. Bootstrap's --bs-code-color
+    // (#d63384) measures 4.50:1 on white — AA by a hair, with no headroom — so
+    // over the admonition's tint it drops to 4.26:1 and fails. Blend it toward
+    // the body colour, the same trick .admonition-title uses above, which keeps
+    // the hue and reaches ~6.3:1 on every admonition type. Dark mode has its own
+    // higher-specificity code rule in _dark.scss and already passes.
+    code {
+      color: color-mix(in srgb, var(--bs-code-color) 70%, var(--bs-body-color));
+    }
   }
 }
 


### PR DESCRIPTION
Two gaps that only a *remote* consumer hits — which is why the repo's own `uses: ./` CI never surfaced them, the same blind spot that produced #187. Found while auditing what a visitor arriving from the [Marketplace listing](https://github.com/marketplace/actions/policypress) actually encounters.

## 1. `actions/checkout` was unpinned inside the action

[`action.yml`](action.yml) had one floating `uses:` left. The other two entries were already SHA-pinned, and `.github/workflows` has been fully pinned since #157 — but this one is different in kind: it runs inside **every consumer's** pipeline, so an upstream tag move would change what every PolicyPress user executes.

Pinned to `11d5960a326750d5838078e36cf38b85af677262` (v4.4.0) — the revision already used across the workflows, verified against `actions/checkout`'s `refs/tags/v4.4.0`.

## 2. The runner requirement was undocumented

The action builds on Nix, which has no Windows support, and ships release binaries for Linux and macOS on x86_64/aarch64 only. Nothing stated this anywhere: the README's only Windows mention is about installing `typst` *locally*, and the installation guide merely happened to use `ubuntu-latest` in its examples.

A consumer on `windows-latest` therefore got as far as installing Nix before dying on an unrelated-looking error, or fell through to the binary resolver's bare `Unsupported platform: MINGW64_NT-10.0-…`.

- **New first step** that fails with an `::error::` annotation naming the reason and linking the guide, before any install work happens.
- **Stated in three places:** `action.yml` (a header comment plus the `description`, so the rendered Marketplace listing carries it), the README's *How it works*, and a *Runner requirements* callout in the installation guide.
- The deep resolver message now names the supported set instead of just the platform it rejected.

Authoring is unaffected — the constraint is on the CI agent only, and the docs say so.

## Incidental: a latent contrast bug the gate caught

Adding a `<code>` span to that new guide callout tripped the axe-core gate: inline code in an admonition measured **4.26:1**, below AA.

Root cause is upstream of my change — Bootstrap's `--bs-code-color` (`#d63384`) is **4.50:1** on white, AA by a hair with zero headroom, so *any* background tint sinks it. Fixed by blending it toward the body colour, which is the technique `.admonition-title` in that same file already uses for exactly this reason (`color-mix(in srgb, … 70%, var(--bs-body-color))`). Reaches ~6.3:1 on all five admonition types while keeping the hue; dark mode has its own higher-specificity rule in `_dark.scss` and already passed.

Note this leaves the *general* headroom problem in place — inline code on any other tinted surface is still one step from failing. I scoped the fix to the admonition rather than restyling every code span site-wide, since that is a theme-wide visual change that deserves its own PR. Happy to file a follow-up issue.

## Verification

- `nix flake check` — **all 11 checks pass** (zola-check, redaction-leak, golden tests, pdf-accessibility/veraPDF, fuzz-smoke, formatting, zig fmt, scf-catalog-fresh, praxis-optional, pre-commit).
- `nix run .#a11y-scan` — PASS, 0 violation types across 10 pages × 2 modes. (Failed before the contrast fix, with the exact selector `.admonition-body > p:nth-child(1) > code`.)
- `nix run .#build-starter` — `✓ starter builds clean: 6 PDFs, private-by-default posture verified`.
- `action.yml` re-parsed with `yq`: all three `uses:` now SHA-pinned, `Check runner platform` is the first step, `branding` intact.
- Guard body passes `shellcheck`; the multi-arg `echo` collapses to the single line GitHub's `::error::` annotation requires.
- Admonition rendering confirmed by headless render across all five types.

Not included, since GitHub gives the composite action no Windows runner in this repo's matrix: an actual `windows-latest` job asserting the guard fires. The condition is a plain `RUNNER_OS` string compare.