### PR TITLE
docs+ci: fix the unreleased CHANGELOG sections, and unblock docs-only PRs

### DIFF
--- a/.github/rulesets/protect-main.json
+++ b/.github/rulesets/protect-main.json
@@ -17,10 +17,7 @@
       "parameters": {
         "strict_required_status_checks_policy": false,
         "do_not_enforce_on_create": true,
-        "required_status_checks": [
-          { "context": "ci (ubuntu-latest)" },
-          { "context": "ci (macos-latest)" }
-        ]
+        "required_status_checks": [{ "context": "ci-gate" }]
       }
     }
   ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,37 @@ jobs:
           path: artifacts/
           retention-days: 7
 
+  # The single required status check for merging into main.
+  #
+  # The `changes` job sizes the `ci` matrix dynamically, so a docs-only PR never
+  # creates a `ci (macos-latest)` job at all. A ruleset cannot require the
+  # per-leg contexts under those conditions: GitHub leaves the context for a job
+  # that was never created permanently "expected", and the PR is unmergeable with
+  # every check that did run passing. That is exactly what happened to #194, the
+  # first genuinely docs-only PR since the ruleset landed in #134.
+  #
+  # This job is always created, so it always reports. protect-main.json requires
+  # `ci-gate` alone; the matrix stays free to shrink without touching branch
+  # protection. A leg that is skipped by design does not relax the gate — the
+  # matrix result must be `success` outright, and `changes` must have succeeded
+  # too, so a failure there cannot pass as a skipped `ci`.
+  ci-gate:
+    needs: [changes, ci]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the ci matrix to have succeeded
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          CI_RESULT: ${{ needs.ci.result }}
+          CI_MATRIX: ${{ needs.changes.outputs.os }}
+        run: |
+          echo "changes=${CHANGES_RESULT} ci=${CI_RESULT} matrix=${CI_MATRIX}"
+          if [ "${CHANGES_RESULT}" != success ] || [ "${CI_RESULT}" != success ]; then
+            echo "::error::CI did not pass (changes=${CHANGES_RESULT}, ci=${CI_RESULT})."
+            exit 1
+          fi
+
   # Release build: runs only on tags, once per target, in parallel. Each leg
   # cross-compiles one target and uploads its binary as an artifact for the
   # publish job to gather. The target list comes from release-targets.json (via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,18 @@ versioning; breaking changes to it bump the major version.
   hue. Caught by the axe-core gate when the runner note above added a code span to
   a callout; dark mode was already compliant via its own rule.
 
+- Docs-only pull requests can be merged again. The `changes` job sizes the `ci`
+  matrix dynamically, so a PR touching only `*.md`/`docs/` never creates a
+  `ci (macos-latest)` job — but `protect-main.json` required that exact context,
+  and GitHub leaves the context of a job that was never created permanently
+  "expected". The PR was then unmergeable with every check that did run passing.
+  CI now ends in a `ci-gate` job that is always created and collapses the whole
+  matrix into one context, and the ruleset requires `ci-gate` alone, so the
+  matrix can shrink without touching branch protection. A skipped leg does not
+  relax the gate: `changes` and the `ci` matrix must both report `success`
+  outright. Latent since the cost optimisation met the ruleset; this was the
+  first genuinely docs-only PR to hit it.
+
 ### Security
 
 - SHA-pinned `actions/checkout` inside `action.yml` (to `v4.4.0`, the revision

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ versioning; breaking changes to it bump the major version.
 
 ### Fixed
 
+- Consecutive footnote references are now readable. Markdown allows adjacent
+  footnote markers, and a control plus its sub-controls is the common case on a
+  `control_footnotes` site — but the theme styled only `.footnote-definition`, so
+  `[^GOV-19][^GOV-19.1][^GOV-19.2]` rendered as "192021", a single 6-digit number
+  rather than three citations. Adjacent markers are now comma-separated
+  ("19,20,21"). The demo policy gained an adjacent-reference run so the a11y scan
+  covers the path (#189).
+- The footnote-definition marker sat on the baseline instead of raised: its
+  `top` was `-0.2.5em`, which has two decimal points, so browsers dropped the
+  whole declaration (#189).
 - The Action now fails fast on a Windows runner, naming the reason and pointing
   at the installation guide, instead of getting as far as installing Nix before
   dying on an unrelated-looking error. Nothing stated the requirement anywhere:
@@ -22,8 +32,8 @@ versioning; breaking changes to it bump the major version.
   headroom — so over an admonition's background tint it fell to 4.26:1. It is now
   blended toward the body colour (the technique `.admonition-title` already used
   for the same reason), reaching ~6.3:1 on every admonition type while keeping the
-  hue. Caught by the axe-core gate when the guide above added a code span to a
-  callout; dark mode was already compliant via its own rule.
+  hue. Caught by the axe-core gate when the runner note above added a code span to
+  a callout; dark mode was already compliant via its own rule.
 
 ### Security
 
@@ -32,16 +42,6 @@ versioning; breaking changes to it bump the major version.
   ref left in the action, and unlike the workflow refs it runs inside every
   consumer's pipeline, so an upstream tag move would have changed what every
   PolicyPress user executes. Completes the pinning work from #157.
-- Consecutive footnote references are now readable. Markdown allows adjacent
-  footnote markers, and a control plus its sub-controls is the common case on a
-  `control_footnotes` site — but the theme styled only `.footnote-definition`, so
-  `[^GOV-19][^GOV-19.1][^GOV-19.2]` rendered as "192021", a single 6-digit number
-  rather than three citations. Adjacent markers are now comma-separated
-  ("19,20,21"). The demo policy gained an adjacent-reference run so the a11y scan
-  covers the path (#189).
-- The footnote-definition marker sat on the baseline instead of raised: its
-  `top` was `-0.2.5em`, which has two decimal points, so browsers dropped the
-  whole declaration (#189).
 
 ## [1.7.1] - 2026-07-25
 


### PR DESCRIPTION
Fallout from #191 and #192 landing back to back.

Both PRs added entries to the same `## [Unreleased]` section. The merge concatenated their additions rather than merging them by heading, so **#191's two footnote entries ended up under `### Security`**:

```
### Security
- SHA-pinned actions/checkout …          ← genuinely security
- Consecutive footnote references …      ← CSS rendering fix
- The footnote-definition marker …       ← CSS rendering fix
```

Neither footnote entry has a security dimension: one adds a separator between adjacent footnote markers, the other corrects a `-0.2.5em` length that browsers were discarding.

## Change

Moved both to `### Fixed` (ordered by merge order), leaving only the `actions/checkout` SHA pin under `### Security`. Also repointed one cross-reference — the contrast entry said "the guide above", which the reorder made inaccurate.

## Why now

`nix run .#bump -- <version>` rolls `[Unreleased]` **verbatim** into the dated release section. Left alone, v1.7.2 would publish a changelog filing a footnote CSS fix as a security fix — and for a compliance tool, a `### Security` heading is a signal people scan for and act on.

Worth knowing for next time: this failure mode is silent. Git produced no conflict, both PRs were green, and the only symptom is a heading that no longer matches its bullets.

## Not included

#190 (the `zig fetch .` guard) landed with no `[Unreleased]` entry. I left that as authored — it is a devShell-only developer guard that does not touch the tool or theme API this changelog tracks, so omitting it is defensible. Say the word if you'd like an entry.

## Verification

- `nix build .#checks.x86_64-linux.formatting` passes.
- Content is byte-identical to what #191 and #192 authored; only the heading each bullet sits under, and the ordering within `### Fixed`, changed.